### PR TITLE
Settings: default Gateway port + token field

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -1,14 +1,21 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = "http://127.0.0.1:8787"
+    // NOTE: OpenClaw Gateway multiplexes WS + HTTP on the same port (default 18789).
+    // HackPanel will eventually use the Gateway WebSocket protocol (not plain REST).
+    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = "http://127.0.0.1:18789"
+    @AppStorage("gatewayToken") private var gatewayToken: String = ""
 
     var body: some View {
         Form {
             Section("Gateway") {
                 TextField("Base URL", text: $gatewayBaseURL)
                     .textFieldStyle(.roundedBorder)
-                Text("Remote hosts are allowed. For now this is used only for future live API wiring.")
+
+                SecureField("Token", text: $gatewayToken)
+                    .textFieldStyle(.roundedBorder)
+
+                Text("Used for upcoming live Gateway wiring. For now the app uses mock data.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -22,3 +29,4 @@ struct SettingsView: View {
         .padding(24)
     }
 }
+


### PR DESCRIPTION
- Fix Settings default Gateway base URL to OpenClaw default port (18789)\n- Add a Token field (stored in AppStorage for now)\n\nNo behavior change yet: app still uses MockGatewayClient; this just prepares the settings surface for upcoming live Gateway wiring.