### PR TITLE
Gateway contract fixtures + decoding tests

### DIFF
--- a/Sources/HackPanelGateway/Client/GatewayFrames.swift
+++ b/Sources/HackPanelGateway/Client/GatewayFrames.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Internal decoding models for Gateway JSON frames.
+///
+/// These are kept `internal` so the test target can validate contract fixtures
+/// without needing a live Gateway connection.
+struct GatewayResponseFrame<P: Decodable & Sendable>: Decodable, Sendable {
+    var type: String
+    var id: String
+    var ok: Bool?
+
+    /// Success payload (variously called `payload` by the Gateway).
+    var payload: P?
+
+    /// Error payload (best-effort, varies by server version).
+    var error: GatewayErrorPayload?
+
+    /// Some servers may include a top-level message even when `error` is present.
+    var message: String?
+}
+
+struct GatewayErrorPayload: Decodable, Sendable {
+    var code: String?
+    var message: String?
+    var details: String?
+    var data: JSONValue?
+}
+
+/// Generic event frame.
+///
+/// Known example: `connect.challenge` may be emitted before/around connect.
+struct GatewayEventFrame<P: Decodable & Sendable>: Decodable, Sendable {
+    var type: String
+    var event: String
+    var payload: P?
+
+    /// Some gateway builds use `data` instead of `payload`.
+    var data: P?
+
+    var normalizedPayload: P? { payload ?? data }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case event
+        case payload
+        case data
+    }
+}
+
+/// JSON catch-all used for best-effort error detail decoding.
+enum JSONValue: Decodable, Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        if let c = try? decoder.singleValueContainer() {
+            if c.decodeNil() { self = .null; return }
+            if let b = try? c.decode(Bool.self) { self = .bool(b); return }
+            if let n = try? c.decode(Double.self) { self = .number(n); return }
+            if let s = try? c.decode(String.self) { self = .string(s); return }
+        }
+
+        if var a = try? decoder.unkeyedContainer() {
+            var arr: [JSONValue] = []
+            while !a.isAtEnd { arr.append(try a.decode(JSONValue.self)) }
+            self = .array(arr)
+            return
+        }
+
+        if let o = try? decoder.container(keyedBy: DynamicKey.self) {
+            var dict: [String: JSONValue] = [:]
+            for k in o.allKeys { dict[k.stringValue] = try o.decode(JSONValue.self, forKey: k) }
+            self = .object(dict)
+            return
+        }
+
+        throw DecodingError.typeMismatch(JSONValue.self, .init(codingPath: decoder.codingPath, debugDescription: "Unsupported JSON"))
+    }
+
+    private struct DynamicKey: CodingKey {
+        var stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int?
+        init?(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
+    }
+}

--- a/Tests/HackPanelGatewayTests/Fixtures/README.md
+++ b/Tests/HackPanelGatewayTests/Fixtures/README.md
@@ -1,0 +1,17 @@
+# Gateway contract fixtures
+
+These JSON files are **golden fixtures** representing real (or best-guess) Gateway frames/payloads.
+They are used by unit tests to validate decoding behavior without needing a live Gateway.
+
+## Adding a new fixture
+
+1. Add a `.json` file to this folder.
+2. Add a decoding test in `Tests/HackPanelGatewayTests/*DecodingTests.swift`:
+   - Use `FixtureLoader.decode(_:fromFixture:decoder:)`.
+   - Assert on the decoded fields that matter.
+3. Run `swift test`.
+
+## Notes
+
+- Some frames differ by Gateway version (e.g. `node.list` can be `{ "nodes": [...] }`, `{ "items": [...] }`, or directly `[ ... ]`). Add fixtures for each observed shape.
+- `connect.challenge` is currently a **best guess** fixture. If you capture a real frame, update `connect_challenge.json` and tighten assertions in `GatewayFrameContractDecodingTests`.

--- a/Tests/HackPanelGatewayTests/Fixtures/connect_auth_failure.json
+++ b/Tests/HackPanelGatewayTests/Fixtures/connect_auth_failure.json
@@ -1,0 +1,13 @@
+{
+  "type": "res",
+  "id": "connect-1",
+  "ok": false,
+  "error": {
+    "code": "auth.invalid",
+    "message": "Invalid token",
+    "details": "Token was missing or expired",
+    "data": {
+      "reason": "missing"
+    }
+  }
+}

--- a/Tests/HackPanelGatewayTests/Fixtures/connect_challenge.json
+++ b/Tests/HackPanelGatewayTests/Fixtures/connect_challenge.json
@@ -1,0 +1,9 @@
+{
+  "type": "event",
+  "event": "connect.challenge",
+  "payload": {
+    "nonce": "b8c1a1f0c6c84c6a9e2c9e1b66f9d101",
+    "algorithm": "ed25519",
+    "expiresAt": "2026-02-08T22:05:00Z"
+  }
+}

--- a/Tests/HackPanelGatewayTests/Fixtures/node_list_array.json
+++ b/Tests/HackPanelGatewayTests/Fixtures/node_list_array.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "node-1",
+    "name": "hackstudio",
+    "connected": true,
+    "lastSeenAt": "2026-02-08T22:00:00Z"
+  },
+  {
+    "id": "node-2",
+    "name": "pi-gateway",
+    "connected": false,
+    "lastSeenAt": "2026-02-08T21:00:00Z"
+  }
+]

--- a/Tests/HackPanelGatewayTests/Fixtures/node_list_nodes.json
+++ b/Tests/HackPanelGatewayTests/Fixtures/node_list_nodes.json
@@ -1,0 +1,16 @@
+{
+  "nodes": [
+    {
+      "nodeId": "node-1",
+      "host": "hackstudio",
+      "connected": true,
+      "lastSeenAt": "2026-02-08T22:00:00Z"
+    },
+    {
+      "deviceId": "node-2",
+      "host": "pi-gateway",
+      "connected": false,
+      "lastSeenAt": "2026-02-08T21:00:00Z"
+    }
+  ]
+}

--- a/Tests/HackPanelGatewayTests/GatewayFrameContractDecodingTests.swift
+++ b/Tests/HackPanelGatewayTests/GatewayFrameContractDecodingTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import HackPanelGateway
+
+final class GatewayFrameContractDecodingTests: XCTestCase {
+    // Best-guess shape for connect.challenge.
+    // TODO: Confirm exact field names with Gateway protocol docs / live capture.
+    private struct ConnectChallengePayload: Decodable, Sendable, Equatable {
+        var nonce: String?
+        var algorithm: String?
+        var expiresAt: Date?
+    }
+
+    func testDecodesConnectChallengeEventFixture() throws {
+        let decoded = try FixtureLoader.decode(GatewayEventFrame<ConnectChallengePayload>.self, fromFixture: "connect_challenge.json", decoder: ISO8601.decoder)
+
+        XCTAssertEqual(decoded.type, "event")
+        XCTAssertEqual(decoded.event, "connect.challenge")
+
+        let payload = try XCTUnwrap(decoded.normalizedPayload)
+        XCTAssertEqual(payload.algorithm, "ed25519")
+        XCTAssertEqual(payload.nonce, "b8c1a1f0c6c84c6a9e2c9e1b66f9d101")
+        XCTAssertEqual(payload.expiresAt, ISO8601.date("2026-02-08T22:05:00Z"))
+    }
+
+    func testDecodesConnectAuthFailureFixture() throws {
+        // Note: payload type is irrelevant on error paths; use an empty placeholder.
+        struct Empty: Decodable, Sendable {}
+
+        let decoded = try FixtureLoader.decode(GatewayResponseFrame<Empty>.self, fromFixture: "connect_auth_failure.json", decoder: ISO8601.decoder)
+
+        XCTAssertEqual(decoded.type, "res")
+        XCTAssertEqual(decoded.id, "connect-1")
+        XCTAssertEqual(decoded.ok, false)
+
+        let err = try XCTUnwrap(decoded.error)
+        XCTAssertEqual(err.code, "auth.invalid")
+        XCTAssertEqual(err.message, "Invalid token")
+        XCTAssertEqual(err.details, "Token was missing or expired")
+        XCTAssertEqual(err.data, .object(["reason": .string("missing")]))
+    }
+}
+
+private extension ISO8601 {
+    static func date(_ iso: String, file: StaticString = #filePath, line: UInt = #line) -> Date {
+        // ISO8601.decoder is configured for OpenClaw timestamps, so reuse it.
+        let data = Data(("\"" + iso + "\"").utf8)
+        do {
+            return try ISO8601.decoder.decode(Date.self, from: data)
+        } catch {
+            XCTFail("Failed parsing ISO8601 date: \(iso) error=\(error)", file: file, line: line)
+            return Date(timeIntervalSince1970: 0)
+        }
+    }
+}

--- a/Tests/HackPanelGatewayTests/GatewayStatusDecodingTests.swift
+++ b/Tests/HackPanelGatewayTests/GatewayStatusDecodingTests.swift
@@ -3,14 +3,8 @@ import XCTest
 
 final class GatewayStatusDecodingTests: XCTestCase {
     func testDecodesGatewayStatusFixture() throws {
-        let data = try XCTUnwrap(Self.fixture(named: "gateway_status.json"))
-        let decoded = try ISO8601.decoder.decode(GatewayStatus.self, from: data)
+        let decoded = try FixtureLoader.decode(GatewayStatus.self, fromFixture: "gateway_status.json", decoder: ISO8601.decoder)
         XCTAssertEqual(decoded.ok, true)
         XCTAssertEqual(decoded.version, "OpenClaw 2026.2.6-3")
-    }
-
-    private static func fixture(named name: String) -> Data? {
-        let url = Bundle.module.url(forResource: name, withExtension: nil)
-        return url.flatMap { try? Data(contentsOf: $0) }
     }
 }

--- a/Tests/HackPanelGatewayTests/NodeListPayloadDecodingTests.swift
+++ b/Tests/HackPanelGatewayTests/NodeListPayloadDecodingTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import HackPanelGateway
+
+final class NodeListPayloadDecodingTests: XCTestCase {
+    func testDecodesNodeList_itemsShape() throws {
+        let decoded = try FixtureLoader.decode(NodeListPayload.self, fromFixture: "node_list_items.json", decoder: ISO8601.decoder)
+        XCTAssertNil(decoded.nodes)
+        XCTAssertEqual(decoded.items?.count, 2)
+        XCTAssertEqual(decoded.items?.first?.id, "node-1")
+    }
+
+    func testDecodesNodeList_nodesShape() throws {
+        let decoded = try FixtureLoader.decode(NodeListPayload.self, fromFixture: "node_list_nodes.json", decoder: ISO8601.decoder)
+        XCTAssertEqual(decoded.nodes?.count, 2)
+        XCTAssertNil(decoded.items)
+        XCTAssertEqual(decoded.nodes?.first?.nodeId, "node-1")
+        XCTAssertEqual(decoded.nodes?.first?.host, "hackstudio")
+    }
+
+    func testDecodesNodeList_arrayShape() throws {
+        let decoded = try FixtureLoader.decode(NodeListPayload.self, fromFixture: "node_list_array.json", decoder: ISO8601.decoder)
+        XCTAssertNil(decoded.nodes)
+        XCTAssertEqual(decoded.items?.count, 2)
+        XCTAssertEqual(decoded.items?.last?.name, "pi-gateway")
+    }
+}

--- a/Tests/HackPanelGatewayTests/Support/FixtureLoader.swift
+++ b/Tests/HackPanelGatewayTests/Support/FixtureLoader.swift
@@ -1,0 +1,19 @@
+import Foundation
+import XCTest
+
+enum FixtureLoader {
+    static func data(named name: String, file: StaticString = #filePath, line: UInt = #line) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: nil), "Missing fixture: \(name)", file: file, line: line)
+        return try Data(contentsOf: url)
+    }
+
+    static func decode<T: Decodable>(_: T.Type, fromFixture name: String, decoder: JSONDecoder, file: StaticString = #filePath, line: UInt = #line) throws -> T {
+        do {
+            let data = try data(named: name, file: file, line: line)
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            XCTFail("Failed decoding fixture \(name) as \(T.self): \(error)", file: file, line: line)
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
Adds golden JSON fixtures + decoding tests for Gateway frame/payload decoding.

Coverage:
- connect.challenge event frame (best-guess payload; TODO to confirm exact fields)
- connect auth failure response frame (error payload shape + JSONValue data)
- node.list payload variants: {items:[...]}, {nodes:[...]}, and direct array

How to add new fixtures:
- Add JSON to Tests/HackPanelGatewayTests/Fixtures
- Add a decoding assertion test using FixtureLoader.decode(...)

No UI changes.