### PR TITLE
Map gateway errors to user-friendly messages

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
+++ b/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
@@ -145,7 +145,7 @@ final class GatewayConnectionStore: ObservableObject {
     }
 
     private func emit(error: Error) {
-        let message = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+        let message = GatewayErrorPresenter.message(for: error)
         let now = Date()
 
         if var current = lastError, current.message == message {
@@ -194,16 +194,7 @@ final class GatewayConnectionStore: ObservableObject {
     }
 
     private func isAuthFailure(error: Error) -> Bool {
-        if let gce = error as? GatewayClientError {
-            switch gce {
-            case .gatewayError(let code, let message, _):
-                let haystack = [code, message].compactMap { $0?.lowercased() }.joined(separator: " ")
-                return haystack.contains("auth") || haystack.contains("unauthorized") || haystack.contains("forbidden")
-            default:
-                break
-            }
-        }
-        let msg = (error as? LocalizedError)?.errorDescription?.lowercased() ?? String(describing: error).lowercased()
-        return msg.contains("unauthorized") || msg.contains("forbidden")
+        GatewayErrorPresenter.isAuthFailure(error)
     }
 }
+

--- a/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
+++ b/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
@@ -1,0 +1,85 @@
+import Foundation
+import HackPanelGateway
+
+/// Maps low-level Gateway / networking errors into user-facing messages.
+///
+/// Keep this logic centralized so UI banners and diagnostics stay consistent.
+enum GatewayErrorPresenter {
+    static func message(for error: Error) -> String {
+        // Prefer our typed gateway errors.
+        if let gce = error as? GatewayClientError {
+            switch gce {
+            case .invalidBaseURL:
+                return "Invalid Gateway URL. Include a scheme like http://127.0.0.1:18789"
+            case .timedOut(let operation):
+                return "Gateway timed out while \(operation)."
+            case .unexpectedFrame:
+                return "Gateway returned an unexpected response. Check Gateway version and try again."
+            case .gatewayError(let code, let message, _):
+                if looksLikeAuthFailure(code: code, message: message) {
+                    return "Authentication failed. Check your Gateway token."
+                }
+
+                // Surface a short, human-friendly server message when available.
+                let summary = [message, code]
+                    .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .first { !$0.isEmpty }
+
+                if let summary {
+                    return "Gateway error: \(summary)"
+                }
+
+                return "Gateway error."
+            case .notImplemented:
+                return "This feature isn’t implemented yet."
+            }
+        }
+
+        // Map common URLSession errors into friendlier, actionable text.
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .unsupportedURL, .badURL:
+                return "Invalid Gateway URL. Include a scheme like http://127.0.0.1:18789"
+            case .cannotConnectToHost, .networkConnectionLost, .dnsLookupFailed, .cannotFindHost:
+                return "Can’t reach the Gateway. Check the URL and that the Gateway is running."
+            case .notConnectedToInternet:
+                return "No network connection."
+            case .timedOut:
+                return "Gateway request timed out."
+            case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasBadDate, .serverCertificateHasUnknownRoot, .serverCertificateNotYetValid:
+                return "Secure connection to Gateway failed. If you’re using HTTPS, check certificates."
+            default:
+                break
+            }
+        }
+
+        return (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+    }
+
+    static func isAuthFailure(_ error: Error) -> Bool {
+        if let gce = error as? GatewayClientError {
+            switch gce {
+            case .gatewayError(let code, let message, _):
+                return looksLikeAuthFailure(code: code, message: message)
+            default:
+                break
+            }
+        }
+
+        if let urlError = error as? URLError {
+            // Auth issues usually aren't represented as URLError, but keep this for completeness.
+            if urlError.code == .userAuthenticationRequired { return true }
+        }
+
+        let msg = (error as? LocalizedError)?.errorDescription?.lowercased() ?? String(describing: error).lowercased()
+        return msg.contains("unauthorized") || msg.contains("forbidden")
+    }
+
+    private static func looksLikeAuthFailure(code: String?, message: String?) -> Bool {
+        let haystack = [code, message]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+
+        return haystack.contains("auth") || haystack.contains("unauthorized") || haystack.contains("forbidden")
+    }
+}

--- a/Tests/HackPanelAppTests/GatewayErrorPresenterTests.swift
+++ b/Tests/HackPanelAppTests/GatewayErrorPresenterTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import HackPanelGateway
+@testable import HackPanelApp
+
+final class GatewayErrorPresenterTests: XCTestCase {
+    func testMessage_invalidBaseURL_isFriendly() {
+        let err = GatewayClientError.invalidBaseURL("127.0.0.1:18789")
+        XCTAssertEqual(
+            GatewayErrorPresenter.message(for: err),
+            "Invalid Gateway URL. Include a scheme like http://127.0.0.1:18789"
+        )
+    }
+
+    func testMessage_authFailure_gatewayError_isFriendly() {
+        let err = GatewayClientError.gatewayError(code: "unauthorized", message: "unauthorized", details: nil)
+        XCTAssertEqual(
+            GatewayErrorPresenter.message(for: err),
+            "Authentication failed. Check your Gateway token."
+        )
+        XCTAssertTrue(GatewayErrorPresenter.isAuthFailure(err))
+    }
+
+    func testMessage_gatewayError_includesServerSummary() {
+        let err = GatewayClientError.gatewayError(code: "bad_request", message: "missing param", details: "x")
+        XCTAssertEqual(
+            GatewayErrorPresenter.message(for: err),
+            "Gateway error: missing param"
+        )
+    }
+
+    func testMessage_urlError_cannotConnect_isFriendly() {
+        let err = URLError(.cannotConnectToHost)
+        XCTAssertEqual(
+            GatewayErrorPresenter.message(for: err),
+            "Can’t reach the Gateway. Check the URL and that the Gateway is running."
+        )
+    }
+}


### PR DESCRIPTION
Implements a small slice of backlog issue #8: map low-level Gateway/network errors into user-friendly messages for the connection banner.

- Add GatewayErrorPresenter to centralize user-facing error messages
- Use it in GatewayConnectionStore for banner/connection state errors
- Add unit tests for common mappings (auth failure, invalid URL, cannot connect)

This keeps scope limited to messaging (no behavior changes to retry/backoff).