### PR TITLE
Docs: PR review checklist link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-> Reviewers: see Docs/PR_REVIEW.md for the standard checklist and PR-comment template.
+> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.
 
 ## What / Why
 

--- a/Docs/PR_REVIEW.md
+++ b/Docs/PR_REVIEW.md
@@ -1,6 +1,6 @@
 # PR Review Checklist (HackPanel)
 
-We use `gh` for PR workflow, and we leave feedback via **PR comments** (not formal reviews).
+We use `gh` for PR workflow. By default, leave feedback via **PR comments** (not formal reviews) unless the author asks for a formal review.
 
 ## Reviewer checklist
 


### PR DESCRIPTION
Small docs tweak: make the PR review checklist link clickable from the PR template, and clarify the default feedback mode.