### PR TITLE
Make diagnostics text selectable

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -35,9 +35,11 @@ struct SettingsView: View {
             }
 
             Section("Diagnostics") {
-                Button("Copy Diagnostics") {
+                Button {
                     copyToPasteboard(diagnosticsText)
                     copiedAt = Date()
+                } label: {
+                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
                 }
 
                 if let copiedAt {
@@ -46,10 +48,18 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                TextEditor(text: .constant(diagnosticsText))
-                    .font(.system(.body, design: .monospaced))
-                    .frame(minHeight: 180)
-                    .disabled(true)
+                ScrollView {
+                    Text(diagnosticsText)
+                        .textSelection(.enabled)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(minHeight: 180)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(.quaternary, lineWidth: 1)
+                }
 
                 Text("Token is fully redacted (last-4 shown).")
                     .font(.caption)


### PR DESCRIPTION
### What\n- Diagnostics text in Settings is now selectable (no longer disabled TextEditor).\n- Copy button uses a standard copy icon label.\n\n### Why\n- Easier to select/copy specific parts of diagnostics, while still keeping a one-click copy button.\n\n### Testing\n- Test Suite 'All tests' started at 2026-02-08 20:58:31.378.
Test Suite 'HackPanelPackageTests.xctest' started at 2026-02-08 20:58:31.378.
Test Suite 'DiagnosticsFormatterTests' started at 2026-02-08 20:58:31.379.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testFormat_includesExpectedFields]' started.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testFormat_includesExpectedFields]' passed (0.001 seconds).
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testRedactToken_doesNotLeakFullToken]' started.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testRedactToken_doesNotLeakFullToken]' passed (0.000 seconds).
Test Suite 'DiagnosticsFormatterTests' passed at 2026-02-08 20:58:31.380.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'GatewayErrorPresenterTests' started at 2026-02-08 20:58:31.380.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_authFailure_gatewayError_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_authFailure_gatewayError_isFriendly]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_gatewayError_includesServerSummary]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_gatewayError_includesServerSummary]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_invalidBaseURL_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_invalidBaseURL_isFriendly]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_urlError_cannotConnect_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_urlError_cannotConnect_isFriendly]' passed (0.000 seconds).
Test Suite 'GatewayErrorPresenterTests' passed at 2026-02-08 20:58:31.381.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'GatewayFrameContractDecodingTests' started at 2026-02-08 20:58:31.381.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectAuthFailureFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectAuthFailureFixture]' passed (0.001 seconds).
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectChallengeEventFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectChallengeEventFixture]' passed (0.000 seconds).
Test Suite 'GatewayFrameContractDecodingTests' passed at 2026-02-08 20:58:31.382.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'GatewayStatusDecodingTests' started at 2026-02-08 20:58:31.382.
Test Case '-[HackPanelGatewayTests.GatewayStatusDecodingTests testDecodesGatewayStatusFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayStatusDecodingTests testDecodesGatewayStatusFixture]' passed (0.000 seconds).
Test Suite 'GatewayStatusDecodingTests' passed at 2026-02-08 20:58:31.382.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'NodeListDecodingTests' started at 2026-02-08 20:58:31.382.
Test Case '-[HackPanelGatewayTests.NodeListDecodingTests testDecodesNodeListItemsFixture]' started.
Test Case '-[HackPanelGatewayTests.NodeListDecodingTests testDecodesNodeListItemsFixture]' passed (0.000 seconds).
Test Suite 'NodeListDecodingTests' passed at 2026-02-08 20:58:31.382.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'NodeListPayloadDecodingTests' started at 2026-02-08 20:58:31.382.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_arrayShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_arrayShape]' passed (0.000 seconds).
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_itemsShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_itemsShape]' passed (0.000 seconds).
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_nodesShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_nodesShape]' passed (0.000 seconds).
Test Suite 'NodeListPayloadDecodingTests' passed at 2026-02-08 20:58:31.383.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'HackPanelPackageTests.xctest' passed at 2026-02-08 20:58:31.383.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
Test Suite 'All tests' passed at 2026-02-08 20:58:31.383.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.004 (0.006) seconds
◇ Test run started.
↳ Testing Library Version: 1400
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.