### PR TITLE
Dashboard: gateway health card shows connection + last check

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
+++ b/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
@@ -169,6 +169,7 @@ final class GatewayConnectionStore: ObservableObject {
         // Attempt immediately.
         while !Task.isCancelled {
             do {
+                lastHealthCheckAt = Date()
                 _ = try await client.fetchStatus()
                 consecutiveFailures = 0
                 clearErrorOnSuccess()
@@ -248,6 +249,7 @@ final class GatewayConnectionStore: ObservableObject {
     }
 
     private func trackCall<T>(_ work: () async throws -> T) async throws -> T {
+        lastHealthCheckAt = Date()
         do {
             let value = try await work()
             consecutiveFailures = 0

--- a/Sources/HackPanelApp/UI/DashboardView.swift
+++ b/Sources/HackPanelApp/UI/DashboardView.swift
@@ -69,11 +69,46 @@ struct DashboardView: View {
                 }
 
                 GlassCard {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Gateway")
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Gateway health")
                             .font(.title3.weight(.semibold))
+
                         HStack(spacing: 12) {
-                            StatusPill(ok: model.status?.ok)
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Connection")
+                                    .font(.caption.weight(.medium))
+                                    .foregroundStyle(.secondary)
+                                Text(connection.state.displayName)
+                                    .font(.body.weight(.medium))
+                            }
+
+                            Divider().opacity(0.25)
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Status")
+                                    .font(.caption.weight(.medium))
+                                    .foregroundStyle(.secondary)
+                                StatusPill(ok: model.status?.ok)
+                            }
+
+                            Spacer()
+
+                            VStack(alignment: .trailing, spacing: 4) {
+                                Text("Last check")
+                                    .font(.caption.weight(.medium))
+                                    .foregroundStyle(.secondary)
+                                if let last = connection.lastHealthCheckAt {
+                                    Text(last, format: .dateTime.month().day().hour().minute().second())
+                                        .font(.caption.weight(.medium))
+                                } else {
+                                    Text("Never")
+                                        .font(.caption.weight(.medium))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+
+                        HStack(spacing: 12) {
                             Text(model.status?.version ?? "Unknown version")
                                 .font(.body)
                             Spacer()

--- a/Tests/HackPanelAppTests/GatewayConnectionStoreHealthCheckTests.swift
+++ b/Tests/HackPanelAppTests/GatewayConnectionStoreHealthCheckTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import HackPanelGateway
+import HackPanelGatewayMocks
+@testable import HackPanelApp
+
+@MainActor
+final class GatewayConnectionStoreHealthCheckTests: XCTestCase {
+    func testLastHealthCheckAt_isSetAfterSuccessfulFetchStatus() async throws {
+        let store = GatewayConnectionStore(client: MockGatewayClient(scenario: .demo))
+        XCTAssertNil(store.lastHealthCheckAt)
+
+        _ = try await store.fetchStatus()
+
+        XCTAssertNotNil(store.lastHealthCheckAt)
+    }
+
+    func testLastHealthCheckAt_isSetAfterFailedFetchStatus() async {
+        struct ThrowingClient: GatewayClient {
+            func fetchStatus() async throws -> GatewayStatus { throw URLError(.cannotConnectToHost) }
+            func fetchNodes() async throws -> [NodeSummary] { [] }
+        }
+
+        let store = GatewayConnectionStore(client: ThrowingClient())
+        XCTAssertNil(store.lastHealthCheckAt)
+
+        do {
+            _ = try await store.fetchStatus()
+            XCTFail("Expected fetchStatus to throw")
+        } catch {
+            // expected
+        }
+
+        XCTAssertNotNil(store.lastHealthCheckAt)
+    }
+}


### PR DESCRIPTION
### What
- Add `lastHealthCheckAt` to `GatewayConnectionStore` and update it on each status poll / client call.
- Update Dashboard/Overview Gateway card to show Connection state + Status pill + Last check timestamp.
- Add basic unit tests for `lastHealthCheckAt`.

### Manual test
1. Run the app.
2. Open Dashboard/Overview.
3. Verify the Gateway health card shows:
   - Connection: Connected/Reconnecting/Disconnected (depends on current state)
   - Status: Running/Down/Unknown
   - Last check: updates after Refresh button / periodic polling

### Notes
- Last check is set on both success and failure, so you can see when the UI last attempted a health call.
