### PR TITLE
Nodes list (minimal): paired nodes, online/offline, last seen

### DIFF
--- a/Sources/HackPanelApp/UI/NodesView+Formatting.swift
+++ b/Sources/HackPanelApp/UI/NodesView+Formatting.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import HackPanelGateway
+
+extension NodesView {
+    static func color(for state: NodeConnectionState) -> Color {
+        switch state {
+        case .online:
+            return .green
+        case .offline:
+            return .gray
+        case .unknown:
+            return .orange
+        }
+    }
+
+    static func lastSeenText(for date: Date?) -> String {
+        guard let date else { return "Last seen: unknown" }
+        return "Last seen \(lastSeenFormatter.localizedString(for: date, relativeTo: Date()))"
+    }
+}
+
+extension NodeConnectionState {
+    var sortRank: Int {
+        switch self {
+        case .online: 0
+        case .offline: 1
+        case .unknown: 2
+        }
+    }
+}

--- a/Sources/HackPanelApp/UI/NodesView.swift
+++ b/Sources/HackPanelApp/UI/NodesView.swift
@@ -7,6 +7,17 @@ final class NodesViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
 
+    var sortedNodes: [NodeSummary] {
+        nodes.sorted { lhs, rhs in
+            if lhs.state != rhs.state {
+                // Online first, then offline, then unknown.
+                return lhs.state.sortRank < rhs.state.sortRank
+            }
+            if lhs.name != rhs.name { return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending }
+            return lhs.id < rhs.id
+        }
+    }
+
     private let gateway: GatewayConnectionStore
 
     init(gateway: GatewayConnectionStore) {
@@ -27,6 +38,12 @@ final class NodesViewModel: ObservableObject {
 }
 
 struct NodesView: View {
+    static let lastSeenFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .short
+        return f
+    }()
+
     @EnvironmentObject private var connection: GatewayConnectionStore
     @StateObject private var model: NodesViewModel
 
@@ -53,20 +70,43 @@ struct NodesView: View {
                     .foregroundStyle(.red)
             }
 
-            List(model.nodes) { node in
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(node.name)
-                        Text(node.id)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+            if model.nodes.isEmpty, !model.isLoading, model.errorMessage == nil {
+                ContentUnavailableView("No paired nodes", systemImage: "sensor.tag.radiowaves.forward")
+            } else {
+                List(model.sortedNodes) { node in
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Circle()
+                            .fill(Self.color(for: node.state))
+                            .frame(width: 8, height: 8)
+                            .padding(.top, 6)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(node.name)
+                                .font(.body)
+
+                            HStack(spacing: 8) {
+                                Text(node.id)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+
+                                Text("•")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+
+                                Text(Self.lastSeenText(for: node.lastSeenAt))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        Text(node.state.rawValue.capitalized)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(node.state == .online ? .green : .secondary)
                     }
-                    Spacer()
-                    Text(node.state.rawValue.capitalized)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(node.state == .online ? .green : .secondary)
+                    .padding(.vertical, 6)
                 }
-                .padding(.vertical, 4)
             }
         }
         .padding(24)


### PR DESCRIPTION
Implements the minimal Nodes list slice:

- Lists paired nodes from the Gateway `node.list` RPC
- Shows online/offline state (dot + label)
- Shows `lastSeenAt` as a relative timestamp (e.g. “Last seen 5m ago”)
- Adds a simple empty state and stable sorting (online first)
