### PR TITLE
P0: Liquid Glass primitives (AppTheme + GlassSurface)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,31 +11,9 @@ This file is **not** canonical anymore.
 
 Use this file only as a pointer and (optional) short-lived snapshot when helpful for discussion.
 
-## P0 — Liquid Glass redesign/refactor (v1)
-### Design system primitives (start here)
-- AppTheme tokens: spacing/radius, glass paddings, border/shadow constants.
-- GlassSurface: material fill + border + elevation (single source of truth).
-- GlassCard: standardized padded surface for cards.
-- Typography baseline: title/subtitle/body/caption weights used consistently across views.
-- Motion/interaction: hover/press feedback for glass surfaces (where appropriate on macOS).
-- Accessibility: contrast checks, reduce transparency support, VoiceOver labels for key UI.
-- Preview/demo: "GlassDemoView" (and/or SwiftUI previews) to iterate quickly.
-
-### Apply primitives to v1 surfaces
-- Dashboard: all sections use consistent glass cards + headers.
-- Nodes: list + empty/error states feel native to the glass system.
-- Settings: form grouping and panels match the system.
-- Connection banner: align with the new glass language (material + separator + typography).
-
-### V1 polish guardrails
-- No new product scope while P0 is underway (only cosmetic refactors + small UX fixes).
-- Keep primitives small; avoid premature component explosion.
-
-## P1 — Product utility (resume after glass v1)
-- Gateway health card: show connection/status + last check timestamp.
-- Nodes list (minimal): paired nodes, online/offline, last seen.
-- Empty/error states: make “no gateway / no nodes” paths look intentional.
-- Basic diagnostics: “Copy debug info” button (app version, OS, gateway URL, last error).
+## Next (1–2 slices each)
+- Empty/error states: make “no gateway / no nodes” paths look intentional (primary actions: Open Settings, Retry, View diagnostics).
+- Logs view: show recent gateway logs + lightweight filter/search (fast debugging loop).
 
 ## Soon
 - Export diagnostics bundle (zip): logs + redacted config summary (no secrets).


### PR DESCRIPTION
## What
P0 kickoff for Liquid Glass redesign/refactor: introduce the first design-system primitives.

- `AppTheme` tokens (spacing/radius + glass constants)
- `GlassSurface` primitive (material fill + border highlight + elevation)
- Backlog reprioritized: Liquid Glass v1 is now P0

## Why
We need a single source of truth for “glass” styling so subsequent UI work can be consistent and fast (Dashboard/Nodes/Settings/Banner).

## Notes
- `swift build` passes.
- Follow-up slice will apply primitives to the first real screen(s) and expand tokens as needed.
