### PR TITLE
P0 Liquid Glass v1: Nodes list surface

### DIFF
--- a/Sources/HackPanelApp/DesignSystem/AppTheme.swift
+++ b/Sources/HackPanelApp/DesignSystem/AppTheme.swift
@@ -4,6 +4,17 @@ import SwiftUI
 ///
 /// Keep this intentionally small and pragmatic: only tokens we actively use.
 enum AppTheme {
+    enum Layout {
+        /// Standard outer padding for top-level screens.
+        static let pagePadding: CGFloat = 24
+
+        /// Default vertical spacing between top-level sections on a screen.
+        static let sectionSpacing: CGFloat = 12
+
+        /// Default vertical padding for list rows.
+        static let rowVerticalPadding: CGFloat = 6
+    }
+
     enum Glass {
         static let cornerRadius: CGFloat = 14
         static let contentPadding: CGFloat = 16

--- a/Sources/HackPanelApp/UI/NodesView.swift
+++ b/Sources/HackPanelApp/UI/NodesView.swift
@@ -78,7 +78,7 @@ struct NodesView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
             HStack {
                 Text("Nodes")
                     .font(.title2.weight(.semibold))
@@ -103,64 +103,75 @@ struct NodesView: View {
             }
 
             if shouldShowGatewayUnavailableState {
-                ContentUnavailableView {
-                    Label(gatewayUnavailableTitle, systemImage: gatewayUnavailableIcon)
-                } description: {
-                    Text(gatewayUnavailableDescription)
-                } actions: {
-                    Button("Retry now") {
-                        connection.retryNow()
-                        Task { await model.refresh() }
+                GlassCard {
+                    ContentUnavailableView {
+                        Label(gatewayUnavailableTitle, systemImage: gatewayUnavailableIcon)
+                    } description: {
+                        Text(gatewayUnavailableDescription)
+                    } actions: {
+                        Button("Retry now") {
+                            connection.retryNow()
+                            Task { await model.refresh() }
+                        }
+                        .disabled(model.isLoading)
                     }
-                    .disabled(model.isLoading)
+                    .frame(maxWidth: .infinity)
                 }
             } else if model.nodes.isEmpty, !model.isLoading, model.errorMessage == nil {
-                ContentUnavailableView {
-                    Label("No paired nodes", systemImage: "sensor.tag.radiowaves.forward")
-                } description: {
-                    Text("Pair a node in your gateway, then refresh.")
-                } actions: {
-                    Button("Refresh") { Task { await model.refresh() } }
-                        .disabled(model.isLoading)
+                GlassCard {
+                    ContentUnavailableView {
+                        Label("No paired nodes", systemImage: "sensor.tag.radiowaves.forward")
+                    } description: {
+                        Text("Pair a node in your gateway, then refresh.")
+                    } actions: {
+                        Button("Refresh") { Task { await model.refresh() } }
+                            .disabled(model.isLoading)
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             } else {
-                List(model.sortedNodes) { node in
-                    HStack(alignment: .firstTextBaseline, spacing: 12) {
-                        Circle()
-                            .fill(Self.color(for: node.state))
-                            .frame(width: 8, height: 8)
-                            .padding(.top, 6)
+                GlassSurface {
+                    List(model.sortedNodes) { node in
+                        HStack(alignment: .firstTextBaseline, spacing: 12) {
+                            Circle()
+                                .fill(Self.color(for: node.state))
+                                .frame(width: 8, height: 8)
+                                .padding(.top, AppTheme.Layout.rowVerticalPadding)
 
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(node.name)
-                                .font(.body)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(node.name)
+                                    .font(.body)
 
-                            HStack(spacing: 8) {
-                                Text(node.id)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 8) {
+                                    Text(node.id)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
 
-                                Text("•")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    Text("•")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
 
-                                Text(Self.lastSeenText(for: node.lastSeenAt))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    Text(Self.lastSeenText(for: node.lastSeenAt))
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
+
+                            Spacer()
+
+                            Text(node.state.rawValue.capitalized)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(node.state == .online ? .green : .secondary)
                         }
-
-                        Spacer()
-
-                        Text(node.state.rawValue.capitalized)
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(node.state == .online ? .green : .secondary)
+                        .padding(.vertical, AppTheme.Layout.rowVerticalPadding)
+                        .listRowBackground(Color.clear)
                     }
-                    .padding(.vertical, 6)
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
                 }
             }
         }
-        .padding(24)
+        .padding(AppTheme.Layout.pagePadding)
         .task(id: connection.refreshToken) { await model.refresh() }
     }
 }


### PR DESCRIPTION
Closes #38.

- Wrap Nodes list container in GlassSurface (material + strokes + shadow).
- Wrap empty/error states in GlassCard for consistent glass styling.
- Replace top-level spacing/padding and row padding magic numbers with AppTheme.Layout tokens.

No behavior changes intended; UI-only refactor.