### PR TITLE
P0 Liquid Glass v1: Settings panels (Diagnostics/Appearance)

### DIFF
--- a/Sources/HackPanelApp/DesignSystem/GlassPrimitivesDemoView.swift
+++ b/Sources/HackPanelApp/DesignSystem/GlassPrimitivesDemoView.swift
@@ -7,7 +7,7 @@ struct GlassPrimitivesDemoView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Liquid Glass")
-                .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                .font(.system(.title, design: .rounded).weight(.semibold))
 
             HStack(spacing: 16) {
                 GlassSurface {
@@ -31,14 +31,12 @@ struct GlassPrimitivesDemoView: View {
                     }
                 }
             }
-
-            Spacer(minLength: 0)
         }
-        .padding(24)
-        .frame(width: 720, height: 360)
     }
 }
 
 #Preview("Liquid Glass Demo") {
     GlassPrimitivesDemoView()
+        .padding(24)
+        .frame(width: 720, height: 360)
 }

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -35,61 +35,65 @@ struct SettingsView: View {
             }
 
             Section("Diagnostics") {
-                LabeledContent("Connection") {
-                    Text(gateway.state.displayName)
-                }
+                GlassCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        LabeledContent("Connection") {
+                            Text(gateway.state.displayName)
+                        }
 
-                LabeledContent("Last error") {
-                    Text(gateway.lastErrorMessage ?? "(none)")
-                        .textSelection(.enabled)
-                }
+                        LabeledContent("Last error") {
+                            Text(gateway.lastErrorMessage ?? "(none)")
+                                .textSelection(.enabled)
+                        }
 
-                if let at = gateway.lastErrorAt {
-                    LabeledContent("Last error at") {
-                        Text(Self.uiTimestampFormatter.string(from: at))
+                        if let at = gateway.lastErrorAt {
+                            LabeledContent("Last error at") {
+                                Text(Self.uiTimestampFormatter.string(from: at))
+                            }
+                        }
+
+                        if let until = reconnectBackoffUntil, until > Date() {
+                            let remaining = max(0, Int(until.timeIntervalSince(Date()).rounded(.up)))
+                            LabeledContent("Reconnect backoff") {
+                                Text("\(remaining)s")
+                            }
+                        }
+
+                        Button {
+                            copyToPasteboard(diagnosticsText)
+                            copiedAt = Date()
+                        } label: {
+                            Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                        }
+
+                        if let copiedAt {
+                            Text("Copied at \(Self.uiTimestampFormatter.string(from: copiedAt)).")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        GlassSurface {
+                            ScrollView {
+                                Text(diagnosticsText)
+                                    .textSelection(.enabled)
+                                    .font(.system(.body, design: .monospaced))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(10)
+                            }
+                            .frame(minHeight: 180)
+                        }
+
+                        Text("Token is fully redacted (last-4 shown).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
-
-                if let until = reconnectBackoffUntil, until > Date() {
-                    let remaining = max(0, Int(until.timeIntervalSince(Date()).rounded(.up)))
-                    LabeledContent("Reconnect backoff") {
-                        Text("\(remaining)s")
-                    }
-                }
-
-                Button {
-                    copyToPasteboard(diagnosticsText)
-                    copiedAt = Date()
-                } label: {
-                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
-                }
-
-                if let copiedAt {
-                    Text("Copied at \(Self.uiTimestampFormatter.string(from: copiedAt)).")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                ScrollView {
-                    Text(diagnosticsText)
-                        .textSelection(.enabled)
-                        .font(.system(.body, design: .monospaced))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
-                }
-                .frame(minHeight: 180)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(.quaternary, lineWidth: 1)
-                }
-
-                Text("Token is fully redacted (last-4 shown).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             Section("Appearance") {
-                GlassPrimitivesDemoView()
+                GlassCard {
+                    GlassPrimitivesDemoView()
+                }
             }
         }
         .padding(24)


### PR DESCRIPTION
Closes #39\n\nScope: visual-only refactor of Settings → Diagnostics + Appearance panels to use Liquid Glass primitives (GlassSurface/GlassCard) and reduce ad-hoc styling.\n\nChanges:\n- Wrap Diagnostics panel content in GlassCard; use GlassSurface for the monospaced diagnostics block (removes custom rounded-rect overlay).\n- Wrap Appearance demo in GlassCard.\n- Make GlassPrimitivesDemoView reusable (remove fixed frame/padding; keep those in Preview only).\n\nTesting:\n- swift test