### PR TITLE
Liquid Glass: solid Reduce Transparency fallback

### DIFF
--- a/Sources/HackPanelApp/DesignSystem/AppTheme.swift
+++ b/Sources/HackPanelApp/DesignSystem/AppTheme.swift
@@ -68,11 +68,15 @@ enum AppTheme {
         static let shadowRadius: CGFloat = 14
         static let shadowYOffset: CGFloat = 8
 
-        /// When Reduce Transparency is enabled, we fall back to an opaque background.
-        static func backgroundFallbackOpacity(contrast: ColorSchemeContrast) -> Double {
+        // Reduce Transparency fallback
+        // When Reduce Transparency is enabled we avoid blur entirely and instead use
+        // a solid semantic background + subtle border so text stays legible in light/dark.
+        static let backgroundFallback: Color = Color(nsColor: .windowBackgroundColor)
+
+        static func fallbackStrokeOpacity(contrast: ColorSchemeContrast) -> Double {
             switch contrast {
-            case .increased: return 0.92
-            default: return 0.86
+            case .increased: return 0.40
+            default: return 0.26
             }
         }
     }

--- a/Sources/HackPanelApp/DesignSystem/GlassSurface.swift
+++ b/Sources/HackPanelApp/DesignSystem/GlassSurface.swift
@@ -25,7 +25,7 @@ struct GlassSurface<Content: View>: View {
             .overlay {
                 shape
                     .strokeBorder(
-                        .white.opacity(AppTheme.Glass.outerStrokeOpacity(contrast: colorSchemeContrast)),
+                        strokeColor.opacity(outerStrokeOpacity),
                         lineWidth: AppTheme.Glass.outerStrokeWidth
                     )
             }
@@ -33,7 +33,7 @@ struct GlassSurface<Content: View>: View {
                 shape
                     .inset(by: 1)
                     .strokeBorder(
-                        .white.opacity(AppTheme.Glass.innerStrokeOpacity(contrast: colorSchemeContrast)),
+                        strokeColor.opacity(innerStrokeOpacity),
                         lineWidth: AppTheme.Glass.innerStrokeWidth
                     )
             }
@@ -47,11 +47,27 @@ struct GlassSurface<Content: View>: View {
 
     private var backgroundStyle: some ShapeStyle {
         if reduceTransparency {
-            return AnyShapeStyle(
-                Color(nsColor: .windowBackgroundColor)
-                    .opacity(AppTheme.Glass.backgroundFallbackOpacity(contrast: colorSchemeContrast))
-            )
+            return AnyShapeStyle(AppTheme.Glass.backgroundFallback)
         }
         return AnyShapeStyle(.ultraThinMaterial)
+    }
+
+    private var strokeColor: Color {
+        // In Reduce Transparency mode we use semantic strokes that work in light/dark.
+        if reduceTransparency { return Color(nsColor: .separatorColor) }
+        return .white
+    }
+
+    private var outerStrokeOpacity: Double {
+        if reduceTransparency { return AppTheme.Glass.fallbackStrokeOpacity(contrast: colorSchemeContrast) }
+        return AppTheme.Glass.outerStrokeOpacity(contrast: colorSchemeContrast)
+    }
+
+    private var innerStrokeOpacity: Double {
+        if reduceTransparency {
+            // Slightly softer inner stroke in fallback mode.
+            return AppTheme.Glass.fallbackStrokeOpacity(contrast: colorSchemeContrast) * 0.55
+        }
+        return AppTheme.Glass.innerStrokeOpacity(contrast: colorSchemeContrast)
     }
 }


### PR DESCRIPTION
Closes #45\n\n- When Reduce Transparency is enabled, GlassSurface now uses a solid semantic background (no blur) + separator-based strokes for better light/dark legibility.\n- Stroke strengths respect Increase Contrast via tokens.\n\nTesting:\n- swift test