### PR TITLE
Liquid Glass: semantic token helpers (anti-sprawl)

### DIFF
--- a/Sources/HackPanelApp/DesignSystem/AppTheme.swift
+++ b/Sources/HackPanelApp/DesignSystem/AppTheme.swift
@@ -30,6 +30,8 @@ enum AppTheme {
     }
 
     enum Glass {
+        // MARK: - Raw geometry tokens (keep small)
+
         static let cornerRadius: CGFloat = 14
         static let contentPadding: CGFloat = 16
 
@@ -41,8 +43,41 @@ enum AppTheme {
         static let pillHorizontalPadding: CGFloat = 10
         static let pillVerticalPadding: CGFloat = 6
 
+        // MARK: - Semantic Liquid Glass tokens (anti-sprawl)
+        /// Prefer these semantic helpers from views (vs ad-hoc `.white.opacity(…)`, magic shadow values, etc.).
+        ///
+        /// Goal: keep the API surface small, but expressive enough that screens don't invent one-off constants.
+
         static let outerStrokeWidth: CGFloat = 0.5
         static let innerStrokeWidth: CGFloat = 0.5
+
+        static func outerStrokeColor(contrast: ColorSchemeContrast) -> Color {
+            .white.opacity(outerStrokeOpacity(contrast: contrast))
+        }
+
+        static func innerStrokeColor(contrast: ColorSchemeContrast) -> Color {
+            .white.opacity(innerStrokeOpacity(contrast: contrast))
+        }
+
+        static func shadowColor(contrast: ColorSchemeContrast) -> Color {
+            .black.opacity(shadowOpacity(contrast: contrast))
+        }
+
+        struct ShadowToken: Sendable {
+            let radius: CGFloat
+            let yOffset: CGFloat
+        }
+
+        /// Current elevation tier for glass cards/surfaces.
+        /// If we add more tiers, keep them here so the app stays consistent.
+        static func elevation(contrast: ColorSchemeContrast) -> ShadowToken {
+            switch contrast {
+            case .increased:
+                return ShadowToken(radius: 14, yOffset: 8)
+            default:
+                return ShadowToken(radius: 14, yOffset: 8)
+            }
+        }
 
         static func outerStrokeOpacity(contrast: ColorSchemeContrast) -> Double {
             switch contrast {
@@ -65,6 +100,7 @@ enum AppTheme {
             }
         }
 
+        // Shadow / elevation (single tier for now)
         static let shadowRadius: CGFloat = 14
         static let shadowYOffset: CGFloat = 8
 
@@ -78,6 +114,17 @@ enum AppTheme {
             case .increased: return 0.40
             default: return 0.26
             }
+        }
+
+        static func surfaceBackgroundStyle(
+            reduceTransparency: Bool,
+            contrast: ColorSchemeContrast
+        ) -> AnyShapeStyle {
+            _ = contrast
+            if reduceTransparency {
+                return AnyShapeStyle(backgroundFallback)
+            }
+            return AnyShapeStyle(.ultraThinMaterial)
         }
     }
 }

--- a/Sources/HackPanelApp/DesignSystem/GlassSurface.swift
+++ b/Sources/HackPanelApp/DesignSystem/GlassSurface.swift
@@ -21,7 +21,13 @@ struct GlassSurface<Content: View>: View {
 
     var body: some View {
         content
-            .background(backgroundStyle, in: shape)
+            .background(
+                AppTheme.Glass.surfaceBackgroundStyle(
+                    reduceTransparency: reduceTransparency,
+                    contrast: colorSchemeContrast
+                ),
+                in: shape
+            )
             .overlay {
                 shape
                     .strokeBorder(
@@ -43,13 +49,6 @@ struct GlassSurface<Content: View>: View {
                 x: 0,
                 y: AppTheme.Glass.shadowYOffset
             )
-    }
-
-    private var backgroundStyle: some ShapeStyle {
-        if reduceTransparency {
-            return AnyShapeStyle(AppTheme.Glass.backgroundFallback)
-        }
-        return AnyShapeStyle(.ultraThinMaterial)
     }
 
     private var strokeColor: Color {


### PR DESCRIPTION
Closes #46.

- Adds a small semantic helper layer in `AppTheme.Glass` (stroke/shadow/background) so views stop inventing one-off glass constants.
- Updates `GlassSurface` to consume those tokens (no visual/behavior changes intended).

Testing: `swift test`
