### PR TITLE
Copy consistency: Reconnect vs Retry

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
+++ b/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
@@ -14,7 +14,7 @@ enum GatewayErrorPresenter {
             case .timedOut(let operation):
                 return "Gateway timed out while \(operation)."
             case .unexpectedFrame:
-                return "Gateway returned an unexpected response. Check Gateway version and try again."
+                return "Gateway returned an unexpected response. Check Gateway version and reconnect."
             case .gatewayError(let code, let message, _):
                 if looksLikeAuthFailure(code: code, message: message) {
                     return "Authentication failed. Check your Gateway token."

--- a/Sources/HackPanelApp/UI/GatewayConnectionBanner.swift
+++ b/Sources/HackPanelApp/UI/GatewayConnectionBanner.swift
@@ -70,9 +70,9 @@ struct GatewayConnectionBanner: View {
 
         if case .reconnecting = connection.state {
             if let s = connection.countdownSeconds {
-                parts.append(s == 0 ? "Retrying now…" : "Retrying in \(s)s")
+                parts.append(s == 0 ? "Reconnecting now…" : "Reconnecting in \(s)s")
             } else {
-                parts.append("Retrying…")
+                parts.append("Reconnecting…")
             }
         }
 

--- a/Sources/HackPanelApp/UI/NodesView.swift
+++ b/Sources/HackPanelApp/UI/NodesView.swift
@@ -69,9 +69,9 @@ struct NodesView: View {
     private var gatewayUnavailableDescription: String {
         switch connection.state {
         case .authFailed:
-            return "Update your gateway token in Settings, then retry."
+            return "Update your gateway token in Settings, then reconnect."
         case .disconnected, .reconnecting:
-            return "Check your gateway URL in Settings, or try again."
+            return "Check your gateway URL in Settings, then reconnect."
         case .connected:
             return ""
         }
@@ -109,7 +109,7 @@ struct NodesView: View {
                     } description: {
                         Text(gatewayUnavailableDescription)
                     } actions: {
-                        Button("Retry now") {
+                        Button("Reconnect") {
                             connection.retryNow()
                             Task { await model.refresh() }
                         }


### PR DESCRIPTION
Fixes #47\n\n- Use **Reconnect** consistently for connection recovery actions (banner + Nodes empty state).\n- Update reconnecting countdown copy to match.\n\nTesting: Test Suite 'All tests' started at 2026-02-09 12:51:02.628.
Test Suite 'HackPanelPackageTests.xctest' started at 2026-02-09 12:51:02.629.
Test Suite 'DeviceIdentityTests' started at 2026-02-09 12:51:02.629.
Test Case '-[HackPanelAppTests.DeviceIdentityTests testFingerprint_isDeterministic]' started.
Test Case '-[HackPanelAppTests.DeviceIdentityTests testFingerprint_isDeterministic]' passed (0.000 seconds).
Test Suite 'DeviceIdentityTests' passed at 2026-02-09 12:51:02.630.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'DiagnosticsFormatterTests' started at 2026-02-09 12:51:02.630.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testFormat_includesExpectedFields]' started.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testFormat_includesExpectedFields]' passed (0.001 seconds).
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testRedactToken_doesNotLeakFullToken]' started.
Test Case '-[HackPanelAppTests.DiagnosticsFormatterTests testRedactToken_doesNotLeakFullToken]' passed (0.000 seconds).
Test Suite 'DiagnosticsFormatterTests' passed at 2026-02-09 12:51:02.630.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'GatewayConnectionStoreForcedStateTests' started at 2026-02-09 12:51:02.630.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testApplyForcedState_falseyValue_isIgnored]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testApplyForcedState_falseyValue_isIgnored]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testApplyForcedState_unknownValue_isIgnored]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testApplyForcedState_unknownValue_isIgnored]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testForcedState_connected]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testForcedState_connected]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testForcedState_reconnecting_hasCountdownAndError]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreForcedStateTests testForcedState_reconnecting_hasCountdownAndError]' passed (0.000 seconds).
Test Suite 'GatewayConnectionStoreForcedStateTests' passed at 2026-02-09 12:51:02.631.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'GatewayConnectionStoreHealthCheckTests' started at 2026-02-09 12:51:02.631.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreHealthCheckTests testLastHealthCheckAt_isSetAfterFailedFetchStatus]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreHealthCheckTests testLastHealthCheckAt_isSetAfterFailedFetchStatus]' passed (0.001 seconds).
Test Case '-[HackPanelAppTests.GatewayConnectionStoreHealthCheckTests testLastHealthCheckAt_isSetAfterSuccessfulFetchStatus]' started.
Test Case '-[HackPanelAppTests.GatewayConnectionStoreHealthCheckTests testLastHealthCheckAt_isSetAfterSuccessfulFetchStatus]' passed (0.000 seconds).
Test Suite 'GatewayConnectionStoreHealthCheckTests' passed at 2026-02-09 12:51:02.632.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'GatewayErrorPresenterTests' started at 2026-02-09 12:51:02.632.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_authFailure_gatewayError_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_authFailure_gatewayError_isFriendly]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_gatewayError_includesServerSummary]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_gatewayError_includesServerSummary]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_invalidBaseURL_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_invalidBaseURL_isFriendly]' passed (0.000 seconds).
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_urlError_cannotConnect_isFriendly]' started.
Test Case '-[HackPanelAppTests.GatewayErrorPresenterTests testMessage_urlError_cannotConnect_isFriendly]' passed (0.000 seconds).
Test Suite 'GatewayErrorPresenterTests' passed at 2026-02-09 12:51:02.632.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'GatewayFrameContractDecodingTests' started at 2026-02-09 12:51:02.632.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectAuthFailureFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectAuthFailureFixture]' passed (0.001 seconds).
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectChallengeEventFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayFrameContractDecodingTests testDecodesConnectChallengeEventFixture]' passed (0.000 seconds).
Test Suite 'GatewayFrameContractDecodingTests' passed at 2026-02-09 12:51:02.633.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'GatewayStatusDecodingTests' started at 2026-02-09 12:51:02.633.
Test Case '-[HackPanelGatewayTests.GatewayStatusDecodingTests testDecodesGatewayStatusFixture]' started.
Test Case '-[HackPanelGatewayTests.GatewayStatusDecodingTests testDecodesGatewayStatusFixture]' passed (0.000 seconds).
Test Suite 'GatewayStatusDecodingTests' passed at 2026-02-09 12:51:02.633.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'NodeListDecodingTests' started at 2026-02-09 12:51:02.633.
Test Case '-[HackPanelGatewayTests.NodeListDecodingTests testDecodesNodeListItemsFixture]' started.
Test Case '-[HackPanelGatewayTests.NodeListDecodingTests testDecodesNodeListItemsFixture]' passed (0.000 seconds).
Test Suite 'NodeListDecodingTests' passed at 2026-02-09 12:51:02.634.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'NodeListPayloadDecodingTests' started at 2026-02-09 12:51:02.634.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_arrayShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_arrayShape]' passed (0.000 seconds).
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_itemsShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_itemsShape]' passed (0.000 seconds).
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_nodesShape]' started.
Test Case '-[HackPanelGatewayTests.NodeListPayloadDecodingTests testDecodesNodeList_nodesShape]' passed (0.000 seconds).
Test Suite 'NodeListPayloadDecodingTests' passed at 2026-02-09 12:51:02.634.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'HackPanelPackageTests.xctest' passed at 2026-02-09 12:51:02.634.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
Test Suite 'All tests' passed at 2026-02-09 12:51:02.634.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.004 (0.006) seconds
◇ Test run started.
↳ Testing Library Version: 1400
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.