### PR TITLE
Docs/Build: add SPM sanity check script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,10 @@
 - Open `Package.swift` in Xcode.
 - Run `HackPanelApp`.
 - Tests: `swift test`.
+
+### SPM sanity check (matches CI)
+Run the same commands CI runs:
+
+```bash
+./Scripts/spm_sanity_check.sh
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ macOS-native “liquid glass” first dashboard for **OpenClaw Gateway**.
 ## Build & Run (local)
 Open `Package.swift` in Xcode and run the `HackPanelApp` executable scheme.
 
+### SPM sanity check (build + tests)
+```bash
+./Scripts/spm_sanity_check.sh
+```
+
 ## Repo hygiene
 - No secrets in repo. Tokens belong in Keychain (later) or local-only settings files (gitignored).
 - PRs must keep scope tight and keep CI green.

--- a/Scripts/spm_sanity_check.sh
+++ b/Scripts/spm_sanity_check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple SPM sanity check for local dev + CI parity.
+# Usage: ./Scripts/spm_sanity_check.sh
+
+echo "==> Swift version"
+swift --version
+
+echo "==> swift build"
+swift build -v
+
+echo "==> swift test"
+swift test -v


### PR DESCRIPTION
Closes #41.\n\nAdds a tiny helper script that runs the same SPM commands CI runs, and documents it in README/CONTRIBUTING.\n\nTesting:\n- swift test -v