### PR TITLE
Add Retry action to disconnected banner

### DIFF
--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -26,7 +26,8 @@ struct RootView: View {
             if gateway.state != .connected {
                 ConnectionBannerView(
                     data: bannerData,
-                    onOpenSettings: { route = .settings }
+                    onOpenSettings: { route = .settings },
+                    onRetry: { gateway.retryNow() }
                 )
             }
 


### PR DESCRIPTION
Implements basic retry/reconnect affordance on disconnected banner with local debounce.

Closes #9.