### PR TITLE
Fix: stop countdown updates after connect

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
+++ b/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
@@ -173,8 +173,8 @@ final class GatewayConnectionStore: ObservableObject {
                 _ = try await client.fetchStatus()
                 consecutiveFailures = 0
                 clearErrorOnSuccess()
+                stopCountdown()
                 state = .connected
-                countdownSeconds = nil
                 refreshToken = UUID()
 
                 try await Task.sleep(nanoseconds: UInt64(pollIntervalSeconds * 1_000_000_000))
@@ -219,6 +219,12 @@ final class GatewayConnectionStore: ObservableObject {
         }
     }
 
+    private func stopCountdown() {
+        countdownTask?.cancel()
+        countdownTask = nil
+        countdownSeconds = nil
+    }
+
     private func emit(error: Error) {
         let message = GatewayErrorPresenter.message(for: error)
         let now = Date()
@@ -254,8 +260,8 @@ final class GatewayConnectionStore: ObservableObject {
             let value = try await work()
             consecutiveFailures = 0
             clearErrorOnSuccess()
+            stopCountdown()
             state = .connected
-            countdownSeconds = nil
             return value
         } catch {
             consecutiveFailures += 1

--- a/Tests/HackPanelAppTests/GatewayConnectionStoreCountdownTaskTests.swift
+++ b/Tests/HackPanelAppTests/GatewayConnectionStoreCountdownTaskTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import HackPanelApp
+import HackPanelGateway
+
+final class GatewayConnectionStoreCountdownTaskTests: XCTestCase {
+    actor SequencedGatewayClient: GatewayClient {
+        private var statusResults: [Result<GatewayStatus, Error>]
+
+        init(statusResults: [Result<GatewayStatus, Error>]) {
+            self.statusResults = statusResults
+        }
+
+        func fetchStatus() async throws -> GatewayStatus {
+            guard !statusResults.isEmpty else {
+                return GatewayStatus(ok: true, version: "test", uptimeSeconds: 0)
+            }
+            let next = statusResults.removeFirst()
+            return try next.get()
+        }
+
+        func fetchNodes() async throws -> [NodeSummary] {
+            return []
+        }
+    }
+
+    @MainActor
+    func testCountdownTaskStopsAfterSuccessfulConnect_inMonitorLoop() async {
+        let client = SequencedGatewayClient(statusResults: [
+            .failure(GatewayClientError.timedOut(operation: "fetchStatus")),
+            .success(GatewayStatus(ok: true, version: "test", uptimeSeconds: 1)),
+        ])
+
+        let store = GatewayConnectionStore(client: client)
+        store.start()
+
+        // Wait long enough for one failure (countdown starts) + next retry success.
+        try? await Task.sleep(nanoseconds: 2_500_000_000)
+
+        XCTAssertEqual(store.state, .connected)
+
+        // If countdownTask wasn't cancelled, it can keep writing countdownSeconds after connected.
+        XCTAssertNil(store.countdownSeconds)
+
+        // Give it another tick to catch the bug (would flip countdownSeconds back to a number).
+        try? await Task.sleep(nanoseconds: 1_250_000_000)
+        XCTAssertNil(store.countdownSeconds)
+
+        store.stop()
+    }
+}


### PR DESCRIPTION
Fixes #77.

- Cancel + nil out `countdownTask` whenever we transition into `.connected` (monitor loop + trackCall success).
- Adds regression test covering failure → countdown starts → success → countdown stops.

Tests: `swift test`
