### PR TITLE
P0: validate Gateway Base URL input (slice for #40)

### DIFF
--- a/Sources/HackPanelApp/GatewaySettingsValidator.swift
+++ b/Sources/HackPanelApp/GatewaySettingsValidator.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum GatewaySettingsValidator {
+    struct ValidationError: LocalizedError, Equatable {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    static func validateBaseURL(_ raw: String) -> Result<URL, ValidationError> {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .failure(.init(message: "Base URL is required."))
+        }
+
+        guard let url = URL(string: trimmed) else {
+            return .failure(.init(message: "Invalid URL. Include a scheme like http://127.0.0.1:18789"))
+        }
+
+        guard let scheme = url.scheme, ["http", "https"].contains(scheme.lowercased()) else {
+            return .failure(.init(message: "URL must start with http:// or https://"))
+        }
+
+        guard url.host != nil else {
+            return .failure(.init(message: "URL must include a host (e.g. 127.0.0.1)"))
+        }
+
+        guard url.port != nil else {
+            return .failure(.init(message: "URL must include a port (e.g. :18789)"))
+        }
+
+        if let path = url.pathComponents.dropFirst().first, !path.isEmpty {
+            return .failure(.init(message: "Base URL should not include a path; use e.g. http://127.0.0.1:18789"))
+        }
+
+        if url.query != nil || url.fragment != nil {
+            return .failure(.init(message: "Base URL should not include query/fragment parameters"))
+        }
+
+        return .success(url)
+    }
+}

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -131,17 +131,15 @@ struct SettingsView: View {
         let trimmedBaseURL = draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedToken = draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard let url = URL(string: trimmedBaseURL) else {
-            validationError = "Invalid URL. Include a scheme like http://127.0.0.1:18789"
+        let url: URL
+        switch GatewaySettingsValidator.validateBaseURL(trimmedBaseURL) {
+        case .success(let validated):
+            url = validated
+            validationError = nil
+        case .failure(let error):
+            validationError = error.message
             return
         }
-
-        guard let scheme = url.scheme, ["http", "https"].contains(scheme.lowercased()) else {
-            validationError = "URL must start with http:// or https://"
-            return
-        }
-
-        validationError = nil
 
         // Persist settings.
         gatewayBaseURL = trimmedBaseURL

--- a/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
+++ b/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import HackPanelApp
+
+final class GatewaySettingsValidatorTests: XCTestCase {
+    func testValidateBaseURL_acceptsValidLocalhostURL() throws {
+        let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789")
+        switch result {
+        case .success(let url):
+            XCTAssertEqual(url.scheme, "http")
+            XCTAssertEqual(url.host, "127.0.0.1")
+            XCTAssertEqual(url.port, 18789)
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error.message)")
+        }
+    }
+
+    func testValidateBaseURL_rejectsMissingScheme() {
+        let result = GatewaySettingsValidator.validateBaseURL("127.0.0.1:18789")
+        XCTAssertFailure(result)
+    }
+
+    func testValidateBaseURL_rejectsMissingPort() {
+        let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1")
+        XCTAssertFailure(result)
+    }
+
+    func testValidateBaseURL_rejectsPath() {
+        let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789/ws")
+        XCTAssertFailure(result)
+    }
+
+    private func XCTAssertFailure(_ result: Result<URL, GatewaySettingsValidator.ValidationError>, file: StaticString = #filePath, line: UInt = #line) {
+        switch result {
+        case .success(let url):
+            XCTFail("Expected failure, got success: \(url)", file: file, line: line)
+        case .failure:
+            XCTAssertTrue(true)
+        }
+    }
+}


### PR DESCRIPTION
Implements stricter Settings input validation for Gateway Base URL (scheme/host/port; no path/query) with unit tests.\n\nCloses #40 (slice).