### PR TITLE
P0: add Retry Now in Settings

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -39,6 +39,11 @@ struct SettingsView: View {
                         applyAndReconnect()
                     }
 
+                    Button("Retry Now") {
+                        gateway.retryNow()
+                    }
+                    .buttonStyle(.borderless)
+
                     Button("Reset to Local Default") {
                         draftBaseURL = "http://127.0.0.1:18789"
                     }


### PR DESCRIPTION
Slice for #40: adds a one-click 'Retry Now' action in Settings to force an immediate reconnect attempt without changing saved config.\n\n- Links: #40\n- Testing: swift test