### PR TITLE
Settings: Apply & Reconnect triggers immediate retry

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -153,6 +153,9 @@ struct SettingsView: View {
         // Apply immediately to the live connection store.
         let cfg = GatewayConfiguration(baseURL: url, token: trimmedToken.isEmpty ? nil : trimmedToken)
         gateway.updateClient(LiveGatewayClient(configuration: cfg))
+
+        // Kick the connection loop immediately so users get fast feedback.
+        gateway.retryNow()
     }
 
     private var diagnosticsText: String {


### PR DESCRIPTION
Small UX fix for #40: after Apply & Reconnect, immediately kicks the connection loop so users get fast feedback.\n\n- Links: #40\n- Tests: swift test