### PR TITLE
Settings: allow Enter to apply; keep validation in sync on reset

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -35,6 +35,9 @@ struct SettingsView: View {
                         hasEditedBaseURL = true
                         validationError = baseURLValidationMessage(for: newValue)
                     }
+                    .onSubmit {
+                        applyAndReconnect()
+                    }
 
                 SecureField("Token", text: $draftToken)
                     .textFieldStyle(.roundedBorder)
@@ -52,6 +55,8 @@ struct SettingsView: View {
 
                     Button("Reset to Local Default") {
                         draftBaseURL = "http://127.0.0.1:18789"
+                        hasEditedBaseURL = true
+                        validationError = baseURLValidationMessage(for: draftBaseURL)
                     }
                     .buttonStyle(.link)
 


### PR DESCRIPTION
Small UX follow-up for Settings (Gateway config):\n\n- Pressing Enter in Base URL field now applies + reconnects\n- Reset-to-default also updates validation state\n\nRefs #40\n\nTesting: swift test