### PR TITLE
docs(pr): use needs-review label to trigger reviewer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 ## Reviewer loop (required)
 - [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
+  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
   - If you can’t add labels, ping `#hackpanel-manager`.
 
 ## What / Why


### PR DESCRIPTION
## What
- Update PR template: add `needs-review` label when PR is ready for reviewer comments.

## Why
- Reviewer automation is now label-gated to avoid noisy drive-by comments.

## How to test
- Open any PR and apply the template; add label `needs-review` and confirm reviewer leaves checklist comment.
