### PR TITLE
P0 #40: centralize default Gateway URL + Settings copy

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
+++ b/Sources/HackPanelApp/Connection/GatewayErrorPresenter.swift
@@ -10,7 +10,7 @@ enum GatewayErrorPresenter {
         if let gce = error as? GatewayClientError {
             switch gce {
             case .invalidBaseURL:
-                return "Invalid Gateway URL. Include a scheme like http://127.0.0.1:18789"
+                return "Invalid Gateway URL. Include a scheme like \(GatewayDefaults.baseURLString)"
             case .timedOut(let operation):
                 return "Gateway timed out while \(operation)."
             case .unexpectedFrame:
@@ -39,7 +39,7 @@ enum GatewayErrorPresenter {
         if let urlError = error as? URLError {
             switch urlError.code {
             case .unsupportedURL, .badURL:
-                return "Invalid Gateway URL. Include a scheme like http://127.0.0.1:18789"
+                return "Invalid Gateway URL. Include a scheme like \(GatewayDefaults.baseURLString)"
             case .cannotConnectToHost, .networkConnectionLost, .dnsLookupFailed, .cannotFindHost:
                 return "Can’t reach the Gateway. Check the URL and that the Gateway is running."
             case .notConnectedToInternet:

--- a/Sources/HackPanelApp/GatewayDefaults.swift
+++ b/Sources/HackPanelApp/GatewayDefaults.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum GatewayDefaults {
+    /// OpenClaw Gateway multiplexes WS + HTTP on the same port (default 18789).
+    static let baseURLString: String = "http://127.0.0.1:18789"
+}

--- a/Sources/HackPanelApp/GatewaySettingsValidator.swift
+++ b/Sources/HackPanelApp/GatewaySettingsValidator.swift
@@ -13,7 +13,7 @@ enum GatewaySettingsValidator {
         }
 
         guard let url = URL(string: trimmed) else {
-            return .failure(.init(message: "Invalid URL. Include a scheme like http://127.0.0.1:18789"))
+            return .failure(.init(message: "Invalid URL. Include a scheme like \(GatewayDefaults.baseURLString)"))
         }
 
         guard let scheme = url.scheme, ["http", "https"].contains(scheme.lowercased()) else {
@@ -29,7 +29,7 @@ enum GatewaySettingsValidator {
         }
 
         if let path = url.pathComponents.dropFirst().first, !path.isEmpty {
-            return .failure(.init(message: "Base URL should not include a path; use e.g. http://127.0.0.1:18789"))
+            return .failure(.init(message: "Base URL should not include a path; use e.g. \(GatewayDefaults.baseURLString)"))
         }
 
         if url.query != nil || url.fragment != nil {

--- a/Sources/HackPanelApp/HackPanelApp.swift
+++ b/Sources/HackPanelApp/HackPanelApp.swift
@@ -4,7 +4,7 @@ import HackPanelGatewayMocks
 
 @main
 struct HackPanelApp: App {
-    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = "http://127.0.0.1:18789"
+    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = GatewayDefaults.baseURLString
     @KeychainStorage("gatewayToken") private var gatewayToken: String = ""
 
     private var client: any GatewayClient {

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -9,7 +9,7 @@ struct SettingsView: View {
 
     // NOTE: OpenClaw Gateway multiplexes WS + HTTP on the same port (default 18789).
     // HackPanel will eventually use the Gateway WebSocket protocol (not plain REST).
-    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = "http://127.0.0.1:18789"
+    @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = GatewayDefaults.baseURLString
     @KeychainStorage("gatewayToken") private var gatewayToken: String = ""
 
     @State private var draftBaseURL: String = ""
@@ -29,8 +29,9 @@ struct SettingsView: View {
     var body: some View {
         Form {
             Section("Gateway") {
-                TextField("Base URL", text: $draftBaseURL)
+                TextField("Gateway URL", text: $draftBaseURL)
                     .textFieldStyle(.roundedBorder)
+                    .help("Example: \(GatewayDefaults.baseURLString)")
                     .onChange(of: draftBaseURL) { _, newValue in
                         hasEditedBaseURL = true
                         validationError = baseURLValidationMessage(for: newValue)
@@ -53,8 +54,8 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    Button("Reset to Local Default") {
-                        draftBaseURL = "http://127.0.0.1:18789"
+                    Button("Reset to Default") {
+                        draftBaseURL = GatewayDefaults.baseURLString
                         hasEditedBaseURL = true
                         validationError = baseURLValidationMessage(for: draftBaseURL)
                     }


### PR DESCRIPTION
Closes #40.\n\nSmall slice toward editable Gateway configuration: centralize the default base URL in one place and reuse it across app launch + Settings reset/help + error/validation copy.