### PR TITLE
Settings: base URL validator allows optional port

### DIFF
--- a/Sources/HackPanelApp/GatewaySettingsValidator.swift
+++ b/Sources/HackPanelApp/GatewaySettingsValidator.swift
@@ -20,13 +20,10 @@ enum GatewaySettingsValidator {
             return .failure(.init(message: "URL must start with http:// or https://"))
         }
 
-        guard url.host != nil else {
+        guard let host = url.host, !host.isEmpty else {
             return .failure(.init(message: "URL must include a host (e.g. 127.0.0.1)"))
         }
 
-        guard url.port != nil else {
-            return .failure(.init(message: "URL must include a port (e.g. :18789)"))
-        }
 
         if let path = url.pathComponents.dropFirst().first, !path.isEmpty {
             return .failure(.init(message: "Base URL should not include a path; use e.g. \(GatewayDefaults.baseURLString)"))

--- a/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
+++ b/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import HackPanelApp
 
 final class GatewaySettingsValidatorTests: XCTestCase {
-    func testValidateBaseURL_acceptsValidLocalhostURL() throws {
+    func testValidateBaseURL_acceptsValidLocalhostURL_withPort() throws {
         let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789")
         switch result {
         case .success(let url):
@@ -14,19 +14,41 @@ final class GatewaySettingsValidatorTests: XCTestCase {
         }
     }
 
+    func testValidateBaseURL_acceptsValidURL_withoutPort() {
+        let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1")
+        switch result {
+        case .success(let url):
+            XCTAssertEqual(url.scheme, "http")
+            XCTAssertEqual(url.host, "127.0.0.1")
+            XCTAssertNil(url.port)
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error.message)")
+        }
+    }
+
     func testValidateBaseURL_rejectsMissingScheme() {
         let result = GatewaySettingsValidator.validateBaseURL("127.0.0.1:18789")
         XCTAssertFailure(result)
     }
 
-    func testValidateBaseURL_rejectsMissingPort() {
-        let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1")
+    func testValidateBaseURL_rejectsNonHttpScheme() {
+        let result = GatewaySettingsValidator.validateBaseURL("ws://127.0.0.1:18789")
+        XCTAssertFailure(result)
+    }
+
+    func testValidateBaseURL_rejectsMissingHost() {
+        let result = GatewaySettingsValidator.validateBaseURL("http://:18789")
         XCTAssertFailure(result)
     }
 
     func testValidateBaseURL_rejectsPath() {
         let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789/ws")
         XCTAssertFailure(result)
+    }
+
+    func testValidateBaseURL_rejectsQueryAndFragment() {
+        XCTAssertFailure(GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789?x=1"))
+        XCTAssertFailure(GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789#frag"))
     }
 
     private func XCTAssertFailure(_ result: Result<URL, GatewaySettingsValidator.ValidationError>, file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Fix `GatewaySettingsValidator.validateBaseURL` to match issue #70 AC: port is optional (scheme must be http/https; host required).
- Tighten host validation so `http://:18789` is treated as invalid.

## Screenshots / Screen recording (for UI changes)
- N/A (no UI changes; validator + tests only).

## How to test
1. Run `swift test`
2. In app Settings → Gateway URL:
   - `http://127.0.0.1` should be accepted
   - `http://:18789` should show inline validation error

## Risk / Rollback plan
- Low risk. If anything regresses, revert this PR (validator change is isolated).

## Accessibility impact
- None.

## Test coverage
- Updated `GatewaySettingsValidatorTests` (valid with/without port; invalid scheme/host/path/query/fragment).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
