### PR TITLE
Docs: align token redaction copy with behavior

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -157,7 +157,7 @@ struct SettingsView: View {
                                 .frame(minHeight: 180)
                             }
 
-                            Text("Token is fully redacted (last-4 shown).")
+                            Text("Token is redacted (last-4 shown when available).")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/Tests/HackPanelAppTests/DiagnosticsFormatterTests.swift
+++ b/Tests/HackPanelAppTests/DiagnosticsFormatterTests.swift
@@ -2,11 +2,31 @@ import XCTest
 @testable import HackPanelApp
 
 final class DiagnosticsFormatterTests: XCTestCase {
-    func testRedactToken_doesNotLeakFullToken() {
+    func testRedactToken_table() {
+        struct Case {
+            let input: String
+            let expected: String
+        }
+
+        let cases: [Case] = [
+            .init(input: "", expected: "(empty)"),
+            .init(input: "   ", expected: "(empty)"),
+            .init(input: "a", expected: "***redacted***"),
+            .init(input: "abc", expected: "***redacted***"),
+            .init(input: "abcd", expected: "***redacted*** (last4: abcd)"),
+            .init(input: "abcdef", expected: "***redacted*** (last4: cdef)"),
+        ]
+
+        for c in cases {
+            XCTAssertEqual(DiagnosticsFormatter.redactToken(c.input), c.expected)
+        }
+    }
+
+    func testRedactToken_doesNotLeakFullToken_whenLongerThan4() {
         let token = "abcd-efgh-ijkl-1234"
         let redacted = DiagnosticsFormatter.redactToken(token)
 
-        XCTAssertFalse(redacted.contains(token), "Should never include the full token")
+        XCTAssertFalse(redacted.contains(token), "Should never include the full token when longer than 4")
         XCTAssertTrue(redacted.contains("1234"), "Should include last 4 when possible")
     }
 


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #78.

- Update Settings → Diagnostics caption to match actual token redaction behavior (last-4 only when available).
- Add a small table-driven unit test for `DiagnosticsFormatter.redactToken` covering empty / <4 / =4 / >4 cases.

## Screenshots / Screen recording (for UI changes)
N/A (caption-only change).

## How to test
1. `swift test`
2. (Optional) Run app → Settings → Diagnostics → confirm caption reads “Token is redacted (last-4 shown when available).”

## Risk / Rollback plan
Low risk (copy + tests only). Revert commit / PR if needed.

## Accessibility impact
- None (static text only).

## Test coverage
- Added table test for `DiagnosticsFormatter.redactToken`.

## Migration notes
- None.

## Security / Secrets check
- [x] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
