### PR TITLE
Undo: reconnect even with auto-apply disabled

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -299,11 +299,9 @@ struct SettingsView: View {
         hasEditedBaseURL = true
         validationError = baseURLValidationMessage(for: draftBaseURL)
 
-        if gatewayAutoApply {
-            scheduleAutoApplyIfNeeded(force: true)
-        }
-
-        showAppliedToast = false
+        // Undo should immediately restore the previously-applied config and reconnect,
+        // regardless of whether auto-apply is enabled.
+        applyAndReconnect(userInitiated: true)
     }
 
     private func applyAndReconnect(userInitiated: Bool) {


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Fixes #89: "Undo" now immediately restores the previous gateway Base URL + token and triggers a reconnect even when Auto-apply is OFF.

## Screenshots / Screen recording (for UI changes)
- N/A (behavioral change to existing toast action).

## How to test
1. Open Settings.
2. Turn **Auto-apply** OFF.
3. Change Gateway URL and click **Apply & Reconnect**.
4. Click **Undo** in the "Applied" toast.
5. Observe: URL/token revert and the connection retries immediately.

## Risk / Rollback plan
- Low risk: only changes the Undo button handler.
- Rollback: revert this commit.

## Accessibility impact
- No change (existing button semantics).

## Test coverage
- `swift test` (package tests) passes.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
