### PR TITLE
Fix Settings Gateway URL/Token fields rendering + editability

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -47,25 +47,29 @@ struct SettingsView: View {
                             .toggleStyle(.switch)
                     }
 
-                    TextField("Gateway URL", text: $draftBaseURL)
-                        .textFieldStyle(.roundedBorder)
-                        .help("Example: \(GatewayDefaults.baseURLString)")
-                        .onChange(of: draftBaseURL) { _, newValue in
-                            hasEditedBaseURL = true
-                            validationError = baseURLValidationMessage(for: newValue)
-                            scheduleAutoApplyIfNeeded()
-                        }
-                        .onSubmit {
-                            if !gatewayAutoApply {
-                                applyAndReconnect(userInitiated: true)
+                    LabeledContent("Gateway URL") {
+                        TextField("", text: $draftBaseURL)
+                            .textFieldStyle(.roundedBorder)
+                            .help("Example: \(GatewayDefaults.baseURLString)")
+                            .onChange(of: draftBaseURL) { _, newValue in
+                                hasEditedBaseURL = true
+                                validationError = baseURLValidationMessage(for: newValue)
+                                scheduleAutoApplyIfNeeded()
                             }
-                        }
+                            .onSubmit {
+                                if !gatewayAutoApply {
+                                    applyAndReconnect(userInitiated: true)
+                                }
+                            }
+                    }
 
-                    SecureField("Token", text: $draftToken)
-                        .textFieldStyle(.roundedBorder)
-                        .onChange(of: draftToken) { _, _ in
-                            scheduleAutoApplyIfNeeded()
-                        }
+                    LabeledContent("Token") {
+                        SecureField("", text: $draftToken)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: draftToken) { _, _ in
+                                scheduleAutoApplyIfNeeded()
+                            }
+                    }
 
                     HStack {
                         if !gatewayAutoApply {


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #124.

The Settings "Gateway URL" + "Token" inputs were reported as missing and/or non-interactive on latest `main`. This PR switches them to explicit `LabeledContent` rows to avoid macOS `Form` layout quirks and ensure the fields always render as editable controls.

## Screenshots / Screen recording (for UI changes)
N/A (layout-only change; no new visuals beyond consistent form rows).

## How to test
1. Run the app and open **Settings**.
2. Verify **Gateway URL** field is visible and accepts typing.
3. Verify **Token** field is visible and accepts typing.
4. (Optional) Toggle Auto-apply off and confirm Apply & Reconnect still works.
5. Run `swift test`.

## Risk / Rollback plan
Low risk (UI layout-only). Revert commit if it causes regressions in Settings rendering.

## Accessibility impact
- No change intended; labels are now explicit `LabeledContent` labels.

## Test coverage
- `swift test` (no new unit tests; UI layout).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
