### PR TITLE
P0: Allow remote gateway hostnames + assume default port

### DIFF
--- a/Sources/HackPanelApp/GatewayDefaults.swift
+++ b/Sources/HackPanelApp/GatewayDefaults.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum GatewayDefaults {
-    /// OpenClaw Gateway multiplexes WS + HTTP on the same port (default 18789).
-    static let baseURLString: String = "http://127.0.0.1:18789"
+    /// OpenClaw Gateway multiplexes WS + HTTP on the same port.
+    static let defaultPort: Int = 18789
+
+    static let baseURLString: String = "http://127.0.0.1:\(defaultPort)"
 }

--- a/Sources/HackPanelApp/GatewaySettingsValidator.swift
+++ b/Sources/HackPanelApp/GatewaySettingsValidator.swift
@@ -33,6 +33,17 @@ enum GatewaySettingsValidator {
             return .failure(.init(message: "Base URL should not include query/fragment parameters"))
         }
 
+        // If the user omits a port, assume the default Gateway port.
+        if url.port == nil {
+            guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                return .failure(.init(message: "Invalid URL. Include a scheme like \(GatewayDefaults.baseURLString)"))
+            }
+            comps.port = GatewayDefaults.defaultPort
+            if let ported = comps.url {
+                return .success(ported)
+            }
+        }
+
         return .success(url)
     }
 }

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -50,7 +50,7 @@ struct SettingsView: View {
                     LabeledContent("Gateway URL") {
                         TextField("", text: $draftBaseURL)
                             .textFieldStyle(.roundedBorder)
-                            .help("Example: \(GatewayDefaults.baseURLString)")
+                            .help("Example: \(GatewayDefaults.baseURLString). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
                             .onChange(of: draftBaseURL) { _, newValue in
                                 hasEditedBaseURL = true
                                 validationError = baseURLValidationMessage(for: newValue)

--- a/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
+++ b/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
@@ -14,13 +14,25 @@ final class GatewaySettingsValidatorTests: XCTestCase {
         }
     }
 
-    func testValidateBaseURL_acceptsValidURL_withoutPort() {
+    func testValidateBaseURL_acceptsValidURL_withoutPort_assumesDefaultPort() {
         let result = GatewaySettingsValidator.validateBaseURL("http://127.0.0.1")
         switch result {
         case .success(let url):
             XCTAssertEqual(url.scheme, "http")
             XCTAssertEqual(url.host, "127.0.0.1")
-            XCTAssertNil(url.port)
+            XCTAssertEqual(url.port, 18789)
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error.message)")
+        }
+    }
+
+    func testValidateBaseURL_acceptsValidHostnameURL_withPort() {
+        let result = GatewaySettingsValidator.validateBaseURL("https://myhost.ts.net:18789")
+        switch result {
+        case .success(let url):
+            XCTAssertEqual(url.scheme, "https")
+            XCTAssertEqual(url.host, "myhost.ts.net")
+            XCTAssertEqual(url.port, 18789)
         case .failure(let error):
             XCTFail("Expected success, got failure: \(error.message)")
         }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #125.

- Accept hostname-based gateway base URLs (e.g. `https://myhost.ts.net:18789`).
- If the user omits a port (e.g. `https://myhost.ts.net`), HackPanel now assumes the default OpenClaw Gateway port `:18789`.
- Settings help text documents the default-port assumption.

## Screenshots / Screen recording (for UI changes)
N/A (help text only).

## How to test
1. In Settings → Gateway URL, enter `https://myhost.ts.net:18789` (or any hostname) and confirm validation passes.
2. Enter `http://127.0.0.1` (no port) and click Apply — it should connect using `:18789`.
3. Regression: `http://127.0.0.1:18789` still works.

## Risk / Rollback plan
Low risk (validation/normalization only). Rollback by reverting this PR.

## Accessibility impact
- None.

## Test coverage
- Updated validator tests to assert default-port normalization.
- Added hostname URL validation test.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
