### PR TITLE
Nodes empty state: Open Settings + Retry

### DIFF
--- a/Sources/HackPanelApp/UI/NodesView.swift
+++ b/Sources/HackPanelApp/UI/NodesView.swift
@@ -49,8 +49,11 @@ struct NodesView: View {
     @EnvironmentObject private var connection: GatewayConnectionStore
     @StateObject private var model: NodesViewModel
 
-    init(gateway: GatewayConnectionStore) {
+    private let onOpenSettings: (() -> Void)?
+
+    init(gateway: GatewayConnectionStore, onOpenSettings: (() -> Void)? = nil) {
         _model = StateObject(wrappedValue: NodesViewModel(gateway: gateway))
+        self.onOpenSettings = onOpenSettings
     }
 
     private var shouldShowGatewayUnavailableState: Bool {
@@ -109,11 +112,17 @@ struct NodesView: View {
                     } description: {
                         Text(gatewayUnavailableDescription)
                     } actions: {
-                        Button("Reconnect") {
+                        if let onOpenSettings {
+                            Button("Open Settings") { onOpenSettings() }
+                                .disabled(model.isLoading)
+                        }
+
+                        Button("Retry") {
                             connection.retryNow()
                             Task { await model.refresh() }
                         }
                         .disabled(model.isLoading)
+                        .accessibilityHint(Text("Retries connecting to the gateway and refreshes the Nodes list"))
                     }
                     .frame(maxWidth: .infinity)
                 }

--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -43,7 +43,7 @@ struct RootView: View {
                 case .overview:
                     DashboardView(gateway: gateway)
                 case .nodes:
-                    NodesView(gateway: gateway)
+                    NodesView(gateway: gateway, onOpenSettings: { route = .settings })
                 case .settings:
                     SettingsView(gateway: gateway)
                 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Adds an in-context **Open Settings** affordance (plus a clearer **Retry**) to the Nodes list gateway-unavailable empty state, so users have obvious next steps when the gateway is misconfigured/unreachable.

Fixes #27.

## Screenshots / Screen recording (for UI changes)
N/A (text/action changes only).

## How to test
1. Launch the app with an invalid gateway URL or missing/invalid token (disconnected/auth-failed).
2. Open **Nodes**.
3. Verify the empty state shows **Open Settings** (when provided) and **Retry**.
4. Click **Open Settings** and confirm you land on the in-app Settings screen.
5. Click **Retry** and confirm it retries connection and refreshes the Nodes list.

## Risk / Rollback plan
Low risk; limited to NodesView empty state actions + wiring a closure from RootView.
Rollback: revert this commit.

## Accessibility impact
- Buttons have clear labels; Retry includes an accessibility hint.

## Test coverage
- Existing test suite: `swift test` (pass).

## Migration notes
None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
