### PR TITLE
Chore: rename 'falsey' -> 'falsy'

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
+++ b/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
@@ -66,7 +66,7 @@ final class GatewayConnectionStore: ObservableObject {
     /// Usage:
     /// `HACKPANEL_FORCE_STATE=connected|reconnecting|disconnected|authFailed`
     ///
-    /// This is DEBUG-only and is ignored for empty/falsey values.
+    /// This is DEBUG-only and is ignored for empty/falsy values.
     func applyForcedStateIfPresent(environment: [String: String], now: Date) {
         guard let raw = environment["HACKPANEL_FORCE_STATE"] else { return }
         let forced = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/Tests/HackPanelAppTests/GatewayConnectionStoreForcedStateTests.swift
+++ b/Tests/HackPanelAppTests/GatewayConnectionStoreForcedStateTests.swift
@@ -40,7 +40,7 @@ final class GatewayConnectionStoreForcedStateTests: XCTestCase {
         XCTAssertEqual(forced.lastError?.lastEmittedAt, now)
     }
 
-    func testApplyForcedState_falseyValue_isIgnored() {
+    func testApplyForcedState_falsyValue_isIgnored() {
         let now = Date(timeIntervalSince1970: 123)
         let store = GatewayConnectionStore(client: NoopClient())
         XCTAssertEqual(store.state, .disconnected)


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #76.

Rename one debug comment + one unit test from "falsey" -> "falsy" to match standard spelling; no behavior changes.

## Screenshots / Screen recording (for UI changes)
N/A (no UI changes).

## How to test
1. `swift test`
2. (Optional) Confirm the renamed test exists: `swift test --filter GatewayConnectionStoreTests/testApplyForcedState_falsyValue_isIgnored`

## Risk / Rollback plan
Very low. Roll back by reverting this commit.

## Accessibility impact
- 

## Test coverage
- 

## Migration notes
- 

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
