### PR TITLE
P2: Gateway Profiles (model + list UI + switch active)

### DIFF
--- a/Sources/HackPanelApp/GatewayProfiles.swift
+++ b/Sources/HackPanelApp/GatewayProfiles.swift
@@ -1,0 +1,110 @@
+import Foundation
+import SwiftUI
+
+struct GatewayProfile: Identifiable, Codable, Equatable {
+    var id: UUID
+    var name: String
+    /// Stored as a string so we can represent invalid/incomplete drafts in UI without losing input.
+    var baseURLString: String
+
+    init(id: UUID = UUID(), name: String, baseURLString: String) {
+        self.id = id
+        self.name = name
+        self.baseURLString = baseURLString
+    }
+
+    var tokenKeychainAccount: String {
+        "gatewayToken.profile.\(id.uuidString)"
+    }
+}
+
+@MainActor
+final class GatewayProfilesStore: ObservableObject {
+    @Published private(set) var profiles: [GatewayProfile]
+    @Published var activeProfileId: UUID
+
+    private static let profilesKey = "gatewayProfiles"
+    private static let activeIdKey = "gatewayActiveProfileId"
+
+    init() {
+        let defaults = UserDefaults.standard
+
+        let initialProfiles: [GatewayProfile] = {
+            if let loaded = Self.loadProfiles(from: defaults, key: Self.profilesKey), !loaded.isEmpty {
+                return loaded
+            }
+            // Default Local profile.
+            return [GatewayProfile(name: "Local", baseURLString: GatewayDefaults.baseURLString)]
+        }()
+
+        let initialActiveId: UUID = {
+            if let active = Self.loadActiveId(from: defaults, key: Self.activeIdKey), initialProfiles.contains(where: { $0.id == active }) {
+                return active
+            }
+            return initialProfiles.first!.id
+        }()
+
+        self.profiles = initialProfiles
+        self.activeProfileId = initialActiveId
+
+        // One-time best-effort migration: copy legacy token into the active profile token slot.
+        // (We keep the legacy key in place for now; Settings keeps them in sync.)
+        let legacyToken = Keychain.readString(account: "gatewayToken") ?? ""
+        if !legacyToken.isEmpty, token(for: activeProfileId).isEmpty {
+            setToken(legacyToken, for: activeProfileId)
+        }
+
+        persist()
+    }
+
+    var activeProfile: GatewayProfile {
+        profiles.first(where: { $0.id == activeProfileId }) ?? profiles.first!
+    }
+
+    func token(for profileId: UUID) -> String {
+        guard let profile = profiles.first(where: { $0.id == profileId }) else { return "" }
+        return Keychain.readString(account: profile.tokenKeychainAccount) ?? ""
+    }
+
+    func setToken(_ token: String, for profileId: UUID) {
+        guard let profile = profiles.first(where: { $0.id == profileId }) else { return }
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            _ = Keychain.delete(account: profile.tokenKeychainAccount)
+        } else {
+            _ = Keychain.writeString(trimmed, account: profile.tokenKeychainAccount)
+        }
+    }
+
+    func setActiveProfile(_ id: UUID) {
+        guard profiles.contains(where: { $0.id == id }) else { return }
+        activeProfileId = id
+        persist()
+    }
+
+    func updateActiveProfile(baseURLString: String) {
+        guard let idx = profiles.firstIndex(where: { $0.id == activeProfileId }) else { return }
+        profiles[idx].baseURLString = baseURLString
+        persist()
+    }
+
+    private func persist() {
+        Self.saveProfiles(profiles, to: UserDefaults.standard, key: Self.profilesKey)
+        UserDefaults.standard.set(activeProfileId.uuidString, forKey: Self.activeIdKey)
+    }
+
+    private static func loadProfiles(from defaults: UserDefaults, key: String) -> [GatewayProfile]? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode([GatewayProfile].self, from: data)
+    }
+
+    private static func saveProfiles(_ profiles: [GatewayProfile], to defaults: UserDefaults, key: String) {
+        guard let data = try? JSONEncoder().encode(profiles) else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    private static func loadActiveId(from defaults: UserDefaults, key: String) -> UUID? {
+        guard let raw = defaults.string(forKey: key) else { return nil }
+        return UUID(uuidString: raw)
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can't add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #136.

Adds a minimal **Gateway Profiles** system so operators can keep multiple saved connections (Local / Tailscale / etc.) and switch between them without retyping.

This slice is intentionally small:
- `GatewayProfile` model + persistence (UserDefaults) + active profile id.
- Per-profile token storage in Keychain (**no plaintext** in the profile list).
- Settings UI: Profile picker; selecting a profile loads its URL/token and reconnects immediately.

## Screenshots / Screen recording (for UI changes)
N/A (Profile picker/menu only).

## How to test
1. Run the app and open **Settings**.
2. In **Gateway → Profile**, confirm a default **Local** profile exists.
3. (Optional) Create a second profile via UserDefaults (CRUD UI is a follow-up), then switch via the Profile picker and confirm:
   - Gateway URL/Token fields update
   - app reconnects (status pill updates)
4. Run `swift test`.

## Risk / Rollback plan
Low risk (Settings-only; persistence isolated). Revert this PR to remove the profiles scaffolding.

## Accessibility impact
- Profile selection uses a standard picker with an explicit label.

## Test coverage
- `swift test` (CI: build-and-test).

## Migration notes
- Best-effort: legacy single token is copied into the active profile token slot if present.

## Security / Secrets check
- [x] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
