### PR TITLE
Providers: read-only provider health screen (stub)

### DIFF
--- a/Sources/HackPanelApp/Support/ProviderHealth.swift
+++ b/Sources/HackPanelApp/Support/ProviderHealth.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct ProviderHealth: Identifiable, Equatable {
+    enum Status: String, CaseIterable, Equatable {
+        case ok
+        case degraded
+        case down
+        case unknown
+
+        var displayName: String {
+            switch self {
+            case .ok: return "OK"
+            case .degraded: return "Degraded"
+            case .down: return "Down"
+            case .unknown: return "Unknown"
+            }
+        }
+
+        var sortRank: Int {
+            switch self {
+            case .down: return 0
+            case .degraded: return 1
+            case .unknown: return 2
+            case .ok: return 3
+            }
+        }
+    }
+
+    var id: String { key }
+
+    /// Stable key for the integration/provider (used for identity + future diffing).
+    var key: String
+    var name: String
+    var status: Status
+    var message: String?
+}

--- a/Sources/HackPanelApp/UI/ProvidersView.swift
+++ b/Sources/HackPanelApp/UI/ProvidersView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+@MainActor
+final class ProvidersViewModel: ObservableObject {
+    @Published var providers: [ProviderHealth] = []
+
+    var sortedProviders: [ProviderHealth] {
+        providers.sorted { lhs, rhs in
+            if lhs.status != rhs.status {
+                return lhs.status.sortRank < rhs.status.sortRank
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    func refreshStub() {
+        // NOTE: This is intentionally a stub until the Gateway exposes provider health.
+        // When the API exists, replace this with a real fetch (and keep the UI contract).
+        providers = [
+            ProviderHealth(key: "openai", name: "OpenAI", status: .unknown, message: nil),
+            ProviderHealth(key: "discord", name: "Discord", status: .unknown, message: nil),
+            ProviderHealth(key: "telegram", name: "Telegram", status: .unknown, message: nil),
+            ProviderHealth(key: "signal", name: "Signal", status: .unknown, message: nil)
+        ]
+    }
+}
+
+struct ProvidersView: View {
+    @EnvironmentObject private var connection: GatewayConnectionStore
+    @StateObject private var model = ProvidersViewModel()
+
+    private let onOpenSettings: (() -> Void)?
+
+    init(onOpenSettings: (() -> Void)? = nil) {
+        self.onOpenSettings = onOpenSettings
+    }
+
+    private var shouldShowGatewayUnavailableState: Bool {
+        connection.state != .connected
+    }
+
+    private var gatewayUnavailableTitle: String {
+        connection.state == .authFailed ? "Authentication required" : "Gateway unavailable"
+    }
+
+    private var gatewayUnavailableIcon: String {
+        connection.state == .authFailed ? "lock.slash" : "wifi.exclamationmark"
+    }
+
+    private var gatewayUnavailableDescription: String {
+        switch connection.state {
+        case .authFailed:
+            return "Update your gateway token in Settings, then reconnect."
+        case .disconnected, .reconnecting:
+            return "Check your gateway URL in Settings, then reconnect."
+        case .connected:
+            return ""
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
+            HStack {
+                Text("Providers")
+                    .font(.title2.weight(.semibold))
+                Spacer()
+                Button {
+                    model.refreshStub()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(shouldShowGatewayUnavailableState)
+                .accessibilityHint(Text("Refreshes provider status"))
+            }
+
+            if shouldShowGatewayUnavailableState {
+                GlassCard {
+                    ContentUnavailableView {
+                        Label(gatewayUnavailableTitle, systemImage: gatewayUnavailableIcon)
+                    } description: {
+                        Text(gatewayUnavailableDescription)
+                    } actions: {
+                        if let onOpenSettings {
+                            Button("Open Settings") { onOpenSettings() }
+                        }
+
+                        Button("Retry") {
+                            connection.retryNow()
+                        }
+                        .accessibilityHint(Text("Retries connecting to the gateway"))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else {
+                GlassSurface {
+                    List(model.sortedProviders) { provider in
+                        HStack(spacing: 12) {
+                            Circle()
+                                .fill(Self.color(for: provider.status))
+                                .frame(width: 8, height: 8)
+                                .padding(.top, AppTheme.Layout.rowVerticalPadding)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(provider.name)
+                                    .font(.body)
+
+                                if let message = provider.message, !message.isEmpty {
+                                    Text(message)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+
+                            Spacer()
+
+                            Text(provider.status.displayName)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(Self.color(for: provider.status))
+                        }
+                        .padding(.vertical, AppTheme.Layout.rowVerticalPadding)
+                        .listRowBackground(Color.clear)
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                }
+
+                GlassCard {
+                    Text("Provider health is currently stubbed until the Gateway exposes an API.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(AppTheme.Layout.pagePadding)
+        .task(id: connection.refreshToken) {
+            if connection.state == .connected {
+                model.refreshStub()
+            }
+        }
+    }
+
+    private static func color(for status: ProviderHealth.Status) -> Color {
+        switch status {
+        case .ok:
+            return .green
+        case .degraded:
+            return .orange
+        case .down:
+            return .red
+        case .unknown:
+            return .secondary
+        }
+    }
+}

--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -11,6 +11,7 @@ struct RootView: View {
     enum Route: Hashable {
         case overview
         case nodes
+        case providers
         case settings
     }
 
@@ -35,6 +36,7 @@ struct RootView: View {
                 List(selection: $route) {
                     NavigationLink("Overview", value: Route.overview)
                     NavigationLink("Nodes", value: Route.nodes)
+                    NavigationLink("Providers", value: Route.providers)
                     NavigationLink("Settings", value: Route.settings)
                 }
                 .navigationSplitViewColumnWidth(min: 180, ideal: 220)
@@ -44,6 +46,8 @@ struct RootView: View {
                     DashboardView(gateway: gateway)
                 case .nodes:
                     NodesView(gateway: gateway, onOpenSettings: { route = .settings })
+                case .providers:
+                    ProvidersView(onOpenSettings: { route = .settings })
                 case .settings:
                     SettingsView(gateway: gateway)
                 }

--- a/Tests/HackPanelAppTests/ProviderHealthTests.swift
+++ b/Tests/HackPanelAppTests/ProviderHealthTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import HackPanelApp
+
+final class ProviderHealthTests: XCTestCase {
+    func testStatus_sortRank_ordersDownDegradedUnknownOk() {
+        XCTAssertLessThan(ProviderHealth.Status.down.sortRank, ProviderHealth.Status.degraded.sortRank)
+        XCTAssertLessThan(ProviderHealth.Status.degraded.sortRank, ProviderHealth.Status.unknown.sortRank)
+        XCTAssertLessThan(ProviderHealth.Status.unknown.sortRank, ProviderHealth.Status.ok.sortRank)
+    }
+
+    func testStatus_displayName_isStable() {
+        XCTAssertEqual(ProviderHealth.Status.ok.displayName, "OK")
+        XCTAssertEqual(ProviderHealth.Status.degraded.displayName, "Degraded")
+        XCTAssertEqual(ProviderHealth.Status.down.displayName, "Down")
+        XCTAssertEqual(ProviderHealth.Status.unknown.displayName, "Unknown")
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #30.

Adds a new **Providers** screen that lists provider/integration health as a read-only view.

- Data is currently **stubbed** (all `.unknown`) until the Gateway exposes a provider-health API.
- UI contract is in place: sorting, status display, and disconnected/auth-failed empty state with **Open Settings** + **Retry**.

## Screenshots / Screen recording (for UI changes)
N/A.

## How to test
1. Run the app and navigate to **Providers** in the sidebar.
2. With gateway **connected**, confirm the list renders.
3. With gateway **disconnected/auth-failed**, confirm the empty state shows **Open Settings** + **Retry**.
4. Run `swift test`.

## Risk / Rollback plan
Low risk (new screen + stubbed model). Revert PR if navigation/UI causes regressions.

## Accessibility impact
- Uses standard `List` rows and labeled buttons; empty state uses `ContentUnavailableView`.

## Test coverage
- Adds unit tests for `ProviderHealth.Status` sort rank + display names.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
