### PR TITLE
Docs: require cross-agent comms PR comment + add PM↔Designer agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 - For UI changes: include screenshots/screen recording and note accessibility checks.
 - Never commit secrets (tokens/keys), even in fixtures.
 
+
+## Coordination & review
+- Use the reviewer checklist + PR comment template: `Docs/PR_REVIEW.md`.
+- **Before merging any active PR**, leave at least one short **cross-agent comms** PR comment (Context / Change / Risk / Testing / Follow-ups).
+  - See: `Docs/working-agreements/pm-designer.md` (template included).
+
 ## Branch naming
 - `feature/<short-name>`
 - `fix/<short-name>`

--- a/Docs/working-agreements/pm-designer.md
+++ b/Docs/working-agreements/pm-designer.md
@@ -1,0 +1,40 @@
+# PM ↔ Designer working agreement (HackPanel)
+
+This doc is the lightweight contract for how Product (PM) and Design collaborate on HackPanel work.
+
+## Goals
+- Keep PRs small and mergeable.
+- Minimize rework by aligning on scope + acceptance criteria early.
+- Ensure “polish” work is shippable and doesn’t sprawl.
+
+## Default workflow
+1) **PM owns scope & acceptance criteria**
+   - Each issue should have: goal, in-scope / out-of-scope, acceptance criteria, and a PR-sized target.
+
+2) **Designer owns UX guidance**
+   - Provide: copy, states (empty/loading/error), and a11y notes.
+   - If a screenshot/mock is needed, keep it narrowly scoped to the slice.
+
+3) **Engineer/agent owns implementation details**
+   - Keep to the slice boundaries; open follow-up issues instead of expanding scope.
+
+## Slice sizing rules
+- Prefer **S/XS PRs** that can be reviewed quickly.
+- If an issue can’t be executed without external data (protocol capture, credentials, etc.), **block it explicitly** and request the smallest missing input.
+
+## PR communication (required)
+Before merging any active PR, leave **at least one** short PR comment using this template:
+
+```text
+Cross-agent comms
+
+Context: <what problem this solves / why now>
+Change: <what changed>
+Risk/impact: <what could break>
+Testing: <what you ran / what CI covers>
+Follow-ups: <anything intentionally deferred>
+```
+
+Notes:
+- This is not a formal review requirement; it’s a coordination checkpoint.
+- Keep it brief. The goal is to reduce surprise merges.


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #42.

- Documented a lightweight cross-agent comms requirement: before merging an active PR, leave at least one short coordination comment (Context / Change / Risk / Testing / Follow-ups).
- Added a stable PM↔Designer working agreement doc and linked it from CONTRIBUTING so it’s discoverable.

## Screenshots / Screen recording (for UI changes)
N/A (docs-only).

## How to test
1. Open `CONTRIBUTING.md` and verify the Coordination & review section links to the docs.
2. Open `Docs/working-agreements/pm-designer.md` and verify the cross-agent comms comment template is present.

## Risk / Rollback plan
No product risk (docs-only). Revert the commit if it’s not desired.

## Accessibility impact
- None.

## Test coverage
- N/A.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
