### PR TITLE
P2: Gateway Profiles — Create profile UI

### DIFF
--- a/Sources/HackPanelApp/GatewayProfiles.swift
+++ b/Sources/HackPanelApp/GatewayProfiles.swift
@@ -88,6 +88,19 @@ final class GatewayProfilesStore: ObservableObject {
         persist()
     }
 
+    @discardableResult
+    func createProfile(name: String, baseURLString: String, token: String) -> GatewayProfile {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalName = trimmedName.isEmpty ? "New Profile" : trimmedName
+
+        let profile = GatewayProfile(name: finalName, baseURLString: baseURLString)
+        profiles.append(profile)
+        setToken(token, for: profile.id)
+        activeProfileId = profile.id
+        persist()
+        return profile
+    }
+
     private func persist() {
         Self.saveProfiles(profiles, to: UserDefaults.standard, key: Self.profilesKey)
         UserDefaults.standard.set(activeProfileId.uuidString, forKey: Self.activeIdKey)

--- a/Tests/HackPanelAppTests/GatewayProfilesStoreTests.swift
+++ b/Tests/HackPanelAppTests/GatewayProfilesStoreTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import HackPanelApp
+
+final class GatewayProfilesStoreTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "gatewayProfiles")
+        UserDefaults.standard.removeObject(forKey: "gatewayActiveProfileId")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "gatewayProfiles")
+        UserDefaults.standard.removeObject(forKey: "gatewayActiveProfileId")
+        super.tearDown()
+    }
+
+    @MainActor
+    func testCreateProfile_persistsProfileAndStoresTokenInKeychain() {
+        let store = GatewayProfilesStore()
+
+        let created = store.createProfile(
+            name: "Remote",
+            baseURLString: "https://example.ts.net:18789",
+            token: "sekrit"
+        )
+
+        XCTAssertEqual(store.activeProfileId, created.id)
+        XCTAssertTrue(store.profiles.contains(where: { $0.id == created.id && $0.name == "Remote" }))
+        XCTAssertEqual(store.token(for: created.id), "sekrit")
+
+        // Verify the token is NOT stored in UserDefaults JSON payload.
+        let raw = UserDefaults.standard.data(forKey: "gatewayProfiles")
+        XCTAssertNotNil(raw)
+        if let raw, let s = String(data: raw, encoding: .utf8) {
+            XCTAssertFalse(s.contains("sekrit"))
+            XCTAssertFalse(s.contains("gatewayToken.profile"))
+        }
+
+        // Best-effort cleanup.
+        _ = Keychain.delete(account: created.tokenKeychainAccount)
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #139.

Adds a simple **New Profile…** flow in Settings so users can create a new gateway profile (name + base URL + token) without overwriting the current one.

- Profiles list persists to UserDefaults.
- Tokens are stored in Keychain (profiles store only references).

## Screenshots / Screen recording (for UI changes)
N/A (small Settings sheet using standard SwiftUI form controls).

## How to test
1. Run the app and open **Settings**.
2. Click **New Profile…**.
3. Enter a Name + Gateway URL + (optional) Token, then click **Create**.
4. Verify the new profile appears in the Profile menu and becomes active.
5. Run `swift test`.

## Risk / Rollback plan
Low risk (Settings UI + small store API). Roll back by reverting this PR.

## Accessibility impact
- Uses standard SwiftUI `TextField` / `SecureField` / buttons; no custom focus handling.

## Test coverage
- Added `GatewayProfilesStoreTests` (create persists profile; token stored in Keychain and not in UserDefaults payload).
- `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [x] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
