### PR TITLE
Tests: align connect.challenge fixture to protocol docs

### DIFF
--- a/Tests/HackPanelGatewayTests/Fixtures/README.md
+++ b/Tests/HackPanelGatewayTests/Fixtures/README.md
@@ -14,4 +14,4 @@ They are used by unit tests to validate decoding behavior without needing a live
 ## Notes
 
 - Some frames differ by Gateway version (e.g. `node.list` can be `{ "nodes": [...] }`, `{ "items": [...] }`, or directly `[ ... ]`). Add fixtures for each observed shape.
-- `connect.challenge` is currently a **best guess** fixture. If you capture a real frame, update `connect_challenge.json` and tighten assertions in `GatewayFrameContractDecodingTests`.
+- `connect.challenge` fixture is aligned to the documented Gateway protocol shape (see `docs/gateway/protocol.md` in `openclaw/openclaw`). If a live capture differs, update `connect_challenge.json` + `GatewayFrameContractDecodingTests` accordingly.

--- a/Tests/HackPanelGatewayTests/Fixtures/connect_challenge.json
+++ b/Tests/HackPanelGatewayTests/Fixtures/connect_challenge.json
@@ -3,7 +3,6 @@
   "event": "connect.challenge",
   "payload": {
     "nonce": "b8c1a1f0c6c84c6a9e2c9e1b66f9d101",
-    "algorithm": "ed25519",
-    "expiresAt": "2026-02-08T22:05:00Z"
+    "ts": 1737264000000
   }
 }

--- a/Tests/HackPanelGatewayTests/GatewayFrameContractDecodingTests.swift
+++ b/Tests/HackPanelGatewayTests/GatewayFrameContractDecodingTests.swift
@@ -2,12 +2,11 @@ import XCTest
 @testable import HackPanelGateway
 
 final class GatewayFrameContractDecodingTests: XCTestCase {
-    // Best-guess shape for connect.challenge.
-    // TODO: Confirm exact field names with Gateway protocol docs / live capture.
+    // Contract shape for `connect.challenge` per the Gateway protocol docs.
+    // Source: docs/gateway/protocol.md (openclaw/openclaw).
     private struct ConnectChallengePayload: Decodable, Sendable, Equatable {
-        var nonce: String?
-        var algorithm: String?
-        var expiresAt: Date?
+        var nonce: String
+        var ts: Int64
     }
 
     func testDecodesConnectChallengeEventFixture() throws {
@@ -17,9 +16,8 @@ final class GatewayFrameContractDecodingTests: XCTestCase {
         XCTAssertEqual(decoded.event, "connect.challenge")
 
         let payload = try XCTUnwrap(decoded.normalizedPayload)
-        XCTAssertEqual(payload.algorithm, "ed25519")
         XCTAssertEqual(payload.nonce, "b8c1a1f0c6c84c6a9e2c9e1b66f9d101")
-        XCTAssertEqual(payload.expiresAt, ISO8601.date("2026-02-08T22:05:00Z"))
+        XCTAssertEqual(payload.ts, 1737264000000)
     }
 
     func testDecodesConnectAuthFailureFixture() throws {
@@ -37,18 +35,5 @@ final class GatewayFrameContractDecodingTests: XCTestCase {
         XCTAssertEqual(err.message, "Invalid token")
         XCTAssertEqual(err.details, "Token was missing or expired")
         XCTAssertEqual(err.data, .object(["reason": .string("missing")]))
-    }
-}
-
-private extension ISO8601 {
-    static func date(_ iso: String, file: StaticString = #filePath, line: UInt = #line) -> Date {
-        // ISO8601.decoder is configured for OpenClaw timestamps, so reuse it.
-        let data = Data(("\"" + iso + "\"").utf8)
-        do {
-            return try ISO8601.decoder.decode(Date.self, from: data)
-        } catch {
-            XCTFail("Failed parsing ISO8601 date: \(iso) error=\(error)", file: file, line: line)
-            return Date(timeIntervalSince1970: 0)
-        }
     }
 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Updates the `connect.challenge` golden fixture + decoding assertions to match the documented Gateway protocol shape (`payload: { nonce, ts }`).
- Removes the unused/incorrect best-guess fields (`algorithm`, `expiresAt`).

Fixes #79.

## Screenshots / Screen recording (for UI changes)
N/A

## How to test
1. `swift test`

## Risk / Rollback plan
- Low risk (test + fixture only). Revert this commit if protocol contract changes again.

## Accessibility impact
- None.

## Test coverage
- Updated `GatewayFrameContractDecodingTests` to assert exact fields for `connect.challenge`.

## Migration notes
- None.

## Security / Secrets check
- [x] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
