### PR TITLE
P2: Gateway Profiles — edit/delete profiles

### DIFF
--- a/Tests/HackPanelAppTests/GatewayProfilesStoreTests.swift
+++ b/Tests/HackPanelAppTests/GatewayProfilesStoreTests.swift
@@ -39,4 +39,52 @@ final class GatewayProfilesStoreTests: XCTestCase {
         // Best-effort cleanup.
         _ = Keychain.delete(account: created.tokenKeychainAccount)
     }
+
+    @MainActor
+    func testUpdateProfile_updatesFieldsAndToken() {
+        let store = GatewayProfilesStore()
+        let created = store.createProfile(name: "Remote", baseURLString: "https://example.ts.net:18789", token: "sekrit")
+
+        store.updateProfile(created.id, name: "Prod", baseURLString: "https://prod.ts.net:18789", token: "newtoken")
+
+        XCTAssertEqual(store.profiles.first(where: { $0.id == created.id })?.name, "Prod")
+        XCTAssertEqual(store.profiles.first(where: { $0.id == created.id })?.baseURLString, "https://prod.ts.net:18789")
+        XCTAssertEqual(store.token(for: created.id), "newtoken")
+
+        _ = Keychain.delete(account: created.tokenKeychainAccount)
+    }
+
+    @MainActor
+    func testDeleteProfile_deletesProfileAndSwitchesActiveWhenNeeded() {
+        let store = GatewayProfilesStore()
+
+        let p1 = store.activeProfile
+        store.setToken("t1", for: p1.id)
+
+        let p2 = store.createProfile(name: "Remote", baseURLString: "https://example.ts.net:18789", token: "t2")
+        XCTAssertEqual(store.activeProfileId, p2.id)
+
+        store.deleteProfile(p2.id)
+
+        XCTAssertFalse(store.profiles.contains(where: { $0.id == p2.id }))
+        XCTAssertNotEqual(store.activeProfileId, p2.id)
+        XCTAssertEqual(store.activeProfileId, p1.id)
+
+        // Best-effort verify keychain token removed.
+        XCTAssertEqual(store.token(for: p2.id), "")
+
+        _ = Keychain.delete(account: p1.tokenKeychainAccount)
+        _ = Keychain.delete(account: p2.tokenKeychainAccount)
+    }
+
+    @MainActor
+    func testDeleteProfile_doesNotDeleteLastRemainingProfile() {
+        let store = GatewayProfilesStore()
+        let only = store.activeProfile
+
+        store.deleteProfile(only.id)
+
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(store.profiles.first?.id, only.id)
+    }
 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #140.

Adds minimal **Edit Profile…** and **Delete Profile…** actions to Settings so saved Gateway Profiles are actually maintainable.

- Edit: name/base URL/token (token stays in Keychain; profile JSON remains token-free)
- Delete: deletes the profile (guard: cannot delete last profile); if deleting active, switches to remaining profile and reconnects

## Screenshots / Screen recording (for UI changes)
N/A (small Settings actions + sheet).

## How to test
1. Open Settings → Gateway.
2. Create a new profile.
3. Click **Edit Profile…** and change name/URL/token → **Save**.
4. Confirm the picker shows the updated name and the app reconnects.
5. Click **Delete Profile…** and confirm:
   - profile disappears
   - active switches back to remaining profile
   - cannot delete the last remaining profile
6. Run `swift test`.

## Risk / Rollback plan
Low–medium (Settings UX + persistence wiring). Revert this PR if profile management behaves unexpectedly.

## Accessibility impact
- Edit/Delete are standard Buttons; sheet uses labeled rows.

## Test coverage
- Added unit tests for: update profile, delete profile (active switch), and guard against deleting last profile.
- `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.