### PR TITLE
P2: First-run onboarding when gateway unconfigured

### DIFF
--- a/Sources/HackPanelApp/Support/GatewayOnboardingGate.swift
+++ b/Sources/HackPanelApp/Support/GatewayOnboardingGate.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Centralizes the heuristics for when we should show the first-run onboarding UI.
+///
+/// Goal: avoid a "blank/confusing" first launch when the Gateway isn't configured yet,
+/// while not nagging users who have successfully connected before.
+enum GatewayOnboardingGate {
+    /// Returns true when the configured base URL string looks missing/invalid.
+    static func isBaseURLInvalid(_ raw: String) -> Bool {
+        if case .failure = GatewaySettingsValidator.validateBaseURL(raw) {
+            return true
+        }
+        return false
+    }
+
+    /// Should we show onboarding right now?
+    ///
+    /// - Parameters:
+    ///   - hasEverConnected: persisted flag; becomes true after any successful connection.
+    ///   - baseURL: current raw base URL string (AppStorage).
+    ///   - connectionState: current gateway connection state.
+    static func shouldShowOnboarding(
+        hasEverConnected: Bool,
+        baseURL: String,
+        connectionState: GatewayConnectionStore.State
+    ) -> Bool {
+        // Always show if configuration is currently invalid.
+        if isBaseURLInvalid(baseURL) { return true }
+
+        // If the user has *never* successfully connected, be explicit on first run.
+        if !hasEverConnected && connectionState != .connected { return true }
+
+        return false
+    }
+}

--- a/Sources/HackPanelApp/UI/OnboardingView.swift
+++ b/Sources/HackPanelApp/UI/OnboardingView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    var onOpenSettings: () -> Void
+    var onReconnect: (() -> Void)?
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Connect HackPanel to a Gateway", systemImage: "bolt.horizontal.circle")
+        } description: {
+            Text("Open Settings to configure your Gateway URL and token. Once connected, this screen will go away automatically.")
+        } actions: {
+            Button("Open Settings") { onOpenSettings() }
+                .keyboardShortcut(",", modifiers: .command)
+                .accessibilityHint("Opens Settings so you can configure the Gateway connection")
+
+            if let onReconnect {
+                Button("Reconnect") { onReconnect() }
+                    .accessibilityHint("Retries connecting to the configured Gateway")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    OnboardingView(onOpenSettings: {}, onReconnect: {})
+}

--- a/Tests/HackPanelAppTests/GatewayOnboardingGateTests.swift
+++ b/Tests/HackPanelAppTests/GatewayOnboardingGateTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import HackPanelApp
+
+final class GatewayOnboardingGateTests: XCTestCase {
+    func test_isBaseURLInvalid_empty_isInvalid() {
+        XCTAssertTrue(GatewayOnboardingGate.isBaseURLInvalid(""))
+        XCTAssertTrue(GatewayOnboardingGate.isBaseURLInvalid("   \n"))
+    }
+
+    func test_isBaseURLInvalid_garbage_isInvalid() {
+        XCTAssertTrue(GatewayOnboardingGate.isBaseURLInvalid("not a url"))
+    }
+
+    func test_isBaseURLInvalid_validURL_isValid() {
+        XCTAssertFalse(GatewayOnboardingGate.isBaseURLInvalid("http://127.0.0.1:3001"))
+    }
+
+    func test_shouldShowOnboarding_invalidBaseURL_alwaysShows() {
+        XCTAssertTrue(
+            GatewayOnboardingGate.shouldShowOnboarding(
+                hasEverConnected: true,
+                baseURL: "",
+                connectionState: .connected
+            )
+        )
+    }
+
+    func test_shouldShowOnboarding_neverConnected_andDisconnected_shows() {
+        XCTAssertTrue(
+            GatewayOnboardingGate.shouldShowOnboarding(
+                hasEverConnected: false,
+                baseURL: "http://127.0.0.1:3001",
+                connectionState: .disconnected
+            )
+        )
+    }
+
+    func test_shouldShowOnboarding_hasConnected_andDisconnected_doesNotShow() {
+        XCTAssertFalse(
+            GatewayOnboardingGate.shouldShowOnboarding(
+                hasEverConnected: true,
+                baseURL: "http://127.0.0.1:3001",
+                connectionState: .disconnected
+            )
+        )
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #145.

Adds a minimal first-run onboarding surface that appears when:
- the Gateway Base URL is missing/invalid, or
- the user has never successfully connected yet and the gateway is currently disconnected.

Once the app reaches `.connected`, we persist `hasEverConnectedToGateway` so onboarding doesn’t reappear unless the config becomes invalid again.

## Screenshots / Screen recording (for UI changes)
N/A (uses `ContentUnavailableView` and existing app styling).

## How to test
1. Fresh install / reset defaults (or set `hasEverConnectedToGateway=false`).
2. Set an invalid Base URL (or clear it) and confirm the onboarding view is shown with **Open Settings** (and no Reconnect button when invalid).
3. Set a valid Base URL and reconnect; once the gateway reaches **Connected**, onboarding should disappear.
4. Relaunch app: onboarding should stay hidden (unless Base URL becomes invalid again).
5. Run `swift test`.

## Risk / Rollback plan
Low risk (UI gating + a small heuristic helper). Revert this PR to remove onboarding and return to prior RootView behavior.

## Accessibility impact
- Uses `ContentUnavailableView` with explicit labels and accessibility hints for actions.
- "Open Settings" uses the standard Command-, shortcut.

## Test coverage
- Added unit tests for onboarding gating heuristics (`GatewayOnboardingGateTests`).
- `swift test`.

## Migration notes
- Adds one new `AppStorage` flag key: `hasEverConnectedToGateway`.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
