### PR TITLE
P1: Copy redacted settings summary (no token)

### DIFF
--- a/Sources/HackPanelApp/Support/DiagnosticsFormatter.swift
+++ b/Sources/HackPanelApp/Support/DiagnosticsFormatter.swift
@@ -78,6 +78,38 @@ enum DiagnosticsFormatter {
         return lines.joined(separator: "\n") + "\n"
     }
 
+    /// Formats a short, redacted settings summary suitable for support/debug.
+    ///
+    /// Intentionally excludes the gateway token and strips URL details down to scheme/host/port.
+    static func formatSettingsSummary(
+        appVersion: String,
+        appBuild: String,
+        osVersion: String,
+        gatewayBaseURL: String,
+        gatewayAutoApply: Bool,
+        connectionState: String,
+        lastErrorMessage: String?
+    ) -> String {
+        var lines: [String] = []
+        lines.append("HackPanel settings summary")
+        lines.append("App version: \(appVersion) (\(appBuild))")
+        lines.append("OS: \(osVersion)")
+        lines.append("Gateway base URL: \(safeHostPortURLString(gatewayBaseURL))")
+        lines.append("Auto-apply: \(gatewayAutoApply ? "On" : "Off")")
+        lines.append("Connection state: \(connectionState)")
+        lines.append("Last error: \((lastErrorMessage?.isEmpty == false) ? lastErrorMessage! : "(none)")")
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func safeHostPortURLString(_ raw: String) -> String {
+        guard let url = URL(string: raw) else { return "(invalid)" }
+        guard let scheme = url.scheme, let host = url.host else { return "(invalid)" }
+        if let port = url.port {
+            return "\(scheme)://\(host):\(port)"
+        }
+        return "\(scheme)://\(host)"
+    }
+
     static func redactToken(_ raw: String) -> String {
         let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty else { return "(empty)" }

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @State private var hasEditedToken: Bool = false
 
     @State private var copiedAt: Date?
+    @State private var copiedSummaryAt: Date?
 
     // Profiles: create/edit/delete UI
     @State private var showCreateProfileSheet: Bool = false
@@ -255,6 +256,19 @@ struct SettingsView: View {
                             }
 
                             Button {
+                                copyToPasteboard(settingsSummaryText)
+                                copiedSummaryAt = Date()
+                            } label: {
+                                Label("Copy Redacted Settings Summary", systemImage: "doc.on.doc")
+                            }
+
+                            if let copiedSummaryAt {
+                                Text("Summary copied at \(Self.uiTimestampFormatter.string(from: copiedSummaryAt)).")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Button {
                                 copyToPasteboard(diagnosticsText)
                                 copiedAt = Date()
                             } label: {
@@ -262,7 +276,7 @@ struct SettingsView: View {
                             }
 
                             if let copiedAt {
-                                Text("Copied at \(Self.uiTimestampFormatter.string(from: copiedAt)).")
+                                Text("Diagnostics copied at \(Self.uiTimestampFormatter.string(from: copiedAt)).")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
@@ -727,6 +741,18 @@ struct SettingsView: View {
 
             testConnectionAt = Date()
         }
+    }
+
+    private var settingsSummaryText: String {
+        DiagnosticsFormatter.formatSettingsSummary(
+            appVersion: appVersion,
+            appBuild: appBuild,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            gatewayBaseURL: gatewayBaseURL,
+            gatewayAutoApply: gatewayAutoApply,
+            connectionState: gateway.state.displayName,
+            lastErrorMessage: gateway.lastErrorMessage
+        )
     }
 
     private var diagnosticsText: String {

--- a/Tests/HackPanelAppTests/DiagnosticsFormatterTests.swift
+++ b/Tests/HackPanelAppTests/DiagnosticsFormatterTests.swift
@@ -60,4 +60,25 @@ final class DiagnosticsFormatterTests: XCTestCase {
         XCTAssertFalse(text.contains("super-secret-token-9999"), "Must not leak full token")
         XCTAssertTrue(text.contains("9999"), "Should include last4 for debugging")
     }
+
+    func testFormatSettingsSummary_isRedactedAndStripsURLDetails() {
+        let text = DiagnosticsFormatter.formatSettingsSummary(
+            appVersion: "1.2.3",
+            appBuild: "456",
+            osVersion: "macOS 14.0 (23A344)",
+            gatewayBaseURL: "http://example.com:18789/path?token=abc#frag",
+            gatewayAutoApply: false,
+            connectionState: "Connected",
+            lastErrorMessage: ""
+        )
+
+        XCTAssertTrue(text.contains("HackPanel settings summary"))
+        XCTAssertTrue(text.contains("App version: 1.2.3 (456)"))
+        XCTAssertTrue(text.contains("OS: macOS 14.0 (23A344)"))
+        XCTAssertTrue(text.contains("Gateway base URL: http://example.com:18789"))
+        XCTAssertFalse(text.contains("/path"), "Should not include path/query/fragment")
+        XCTAssertFalse(text.contains("token=abc"), "Should not include query")
+        XCTAssertTrue(text.contains("Auto-apply: Off"))
+        XCTAssertTrue(text.contains("Last error: (none)"))
+    }
 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #146.

Adds a "Copy Redacted Settings Summary" action in **Settings → Diagnostics** for quick support/debug sharing.

- Summary includes: app version/build, OS version, gateway base URL (scheme/host/port only), auto-apply state, connection state, last error.
- Summary intentionally excludes the gateway token and strips URL path/query/fragment.

## Screenshots / Screen recording (for UI changes)
N/A (adds an additional button in existing Diagnostics card).

## How to test
1. Run the app and open **Settings → Diagnostics**.
2. Click **Copy Redacted Settings Summary**.
3. Paste into a text editor and verify:
   - No token is included.
   - Gateway base URL is scheme/host/port only (no path/query/fragment).
4. Run `swift test`.

## Risk / Rollback plan
Low risk (diagnostics-only formatting + copy action). Revert this PR if it causes any issues.

## Accessibility impact
- Uses a standard SwiftUI `Button` with an explicit label.

## Test coverage
- Added a unit test for settings summary formatting + URL stripping.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
