### PR TITLE
Add operator Timeline screen

### DIFF
--- a/Sources/HackPanelApp/Timeline/OperatorTimelineStore.swift
+++ b/Sources/HackPanelApp/Timeline/OperatorTimelineStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Combine
+
+@MainActor
+final class OperatorTimelineStore: ObservableObject {
+    struct Event: Identifiable, Equatable {
+        enum Kind: Equatable {
+            case connectionState
+            case connectionError
+        }
+
+        var id: UUID = UUID()
+        var kind: Kind
+        var timestamp: Date
+        var title: String
+        var detail: String?
+    }
+
+    @Published private(set) var events: [Event] = []
+
+    private let maxEvents: Int
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(maxEvents: Int = 200) {
+        self.maxEvents = maxEvents
+    }
+
+    func startObserving(connection: GatewayConnectionStore) {
+        cancellables.removeAll()
+
+        // Connection state changes.
+        connection.$state
+            .removeDuplicates()
+            .sink { [weak self] state in
+                self?.record(state: state, at: Date())
+            }
+            .store(in: &cancellables)
+
+        // Error message changes.
+        connection.$lastError
+            .removeDuplicates()
+            .sink { [weak self] err in
+                guard let self else { return }
+                guard let err else { return }
+                self.record(errorMessage: err.message, at: err.lastEmittedAt)
+            }
+            .store(in: &cancellables)
+    }
+
+    func clear() {
+        events.removeAll()
+    }
+
+    // MARK: - Recording (testable)
+
+    func record(state: GatewayConnectionStore.State, at timestamp: Date) {
+        let title: String
+        let detail: String?
+
+        switch state {
+        case .connected:
+            title = "Gateway connected"
+            detail = nil
+        case .disconnected:
+            title = "Gateway disconnected"
+            detail = nil
+        case .authFailed:
+            title = "Gateway auth failed"
+            detail = "Update your token in Settings, then reconnect."
+        case .reconnecting(let nextRetryAt):
+            title = "Gateway reconnecting"
+            let seconds = max(0, Int(nextRetryAt.timeIntervalSince(timestamp)))
+            detail = seconds > 0 ? "Retrying in ~\(seconds)s" : "Retrying now"
+        }
+
+        append(Event(kind: .connectionState, timestamp: timestamp, title: title, detail: detail))
+    }
+
+    func record(errorMessage: String, at timestamp: Date) {
+        append(Event(kind: .connectionError, timestamp: timestamp, title: "Connection error", detail: errorMessage))
+    }
+
+    private func append(_ event: Event) {
+        events.insert(event, at: 0)
+        if events.count > maxEvents {
+            events.removeLast(events.count - maxEvents)
+        }
+    }
+}

--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -12,6 +12,7 @@ struct RootView: View {
         case overview
         case nodes
         case providers
+        case timeline
         case settings
     }
 
@@ -40,6 +41,7 @@ struct RootView: View {
                     NavigationLink("Overview", value: Route.overview)
                     NavigationLink("Nodes", value: Route.nodes)
                     NavigationLink("Providers", value: Route.providers)
+                    NavigationLink("Timeline", value: Route.timeline)
                     NavigationLink("Settings", value: Route.settings)
                 }
                 .navigationSplitViewColumnWidth(min: 180, ideal: 220)
@@ -61,6 +63,8 @@ struct RootView: View {
                         NodesView(gateway: gateway, onOpenSettings: { route = .settings })
                     case .providers:
                         ProvidersView(onOpenSettings: { route = .settings })
+                    case .timeline:
+                        TimelineView(onOpenSettings: { route = .settings })
                     case .settings:
                         SettingsView(gateway: gateway)
                     }

--- a/Sources/HackPanelApp/UI/TimelineView.swift
+++ b/Sources/HackPanelApp/UI/TimelineView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct TimelineView: View {
+    private static let timestampFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateStyle = .none
+        df.timeStyle = .short
+        return df
+    }()
+
+    @EnvironmentObject private var connection: GatewayConnectionStore
+    @StateObject private var timeline: OperatorTimelineStore = OperatorTimelineStore()
+
+    private let onOpenSettings: (() -> Void)?
+
+    init(onOpenSettings: (() -> Void)? = nil) {
+        self.onOpenSettings = onOpenSettings
+    }
+
+    private var shouldShowGatewayUnavailableState: Bool {
+        connection.state != .connected && timeline.events.isEmpty
+    }
+
+    private var gatewayUnavailableTitle: String {
+        connection.state == .authFailed ? "Authentication required" : "Gateway unavailable"
+    }
+
+    private var gatewayUnavailableIcon: String {
+        connection.state == .authFailed ? "lock.slash" : "wifi.exclamationmark"
+    }
+
+    private var gatewayUnavailableDescription: String {
+        switch connection.state {
+        case .authFailed:
+            return "Update your gateway token in Settings, then reconnect."
+        case .disconnected, .reconnecting:
+            return "Check your gateway URL in Settings, then reconnect."
+        case .connected:
+            return ""
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
+            HStack {
+                Text("Timeline")
+                    .font(.title2.weight(.semibold))
+                Spacer()
+                Button("Clear") { timeline.clear() }
+                    .disabled(timeline.events.isEmpty)
+            }
+
+            if shouldShowGatewayUnavailableState {
+                GlassCard {
+                    ContentUnavailableView {
+                        Label(gatewayUnavailableTitle, systemImage: gatewayUnavailableIcon)
+                    } description: {
+                        Text(gatewayUnavailableDescription)
+                    } actions: {
+                        if let onOpenSettings {
+                            Button("Open Settings") { onOpenSettings() }
+                        }
+                        Button("Reconnect") {
+                            connection.retryNow()
+                        }
+                        .accessibilityHint(Text("Retries connecting to the gateway"))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else if timeline.events.isEmpty {
+                GlassCard {
+                    ContentUnavailableView {
+                        Label("No events yet", systemImage: "clock")
+                    } description: {
+                        Text("Connection and error events will show up here as you use the app.")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else {
+                GlassSurface {
+                    List(timeline.events) { event in
+                        HStack(alignment: .firstTextBaseline, spacing: 12) {
+                            Image(systemName: icon(for: event.kind))
+                                .foregroundStyle(color(for: event.kind))
+                                .frame(width: 18)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                    Text(event.title)
+                                        .font(.body)
+
+                                    Spacer()
+
+                                    Text(Self.timestampFormatter.string(from: event.timestamp))
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                if let detail = event.detail {
+                                    Text(detail)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .padding(.vertical, AppTheme.Layout.rowVerticalPadding)
+                        .listRowBackground(Color.clear)
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                }
+            }
+        }
+        .padding(AppTheme.Layout.pagePadding)
+        .task {
+            timeline.startObserving(connection: connection)
+        }
+    }
+
+    private func icon(for kind: OperatorTimelineStore.Event.Kind) -> String {
+        switch kind {
+        case .connectionState:
+            return "antenna.radiowaves.left.and.right"
+        case .connectionError:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func color(for kind: OperatorTimelineStore.Event.Kind) -> Color {
+        switch kind {
+        case .connectionState:
+            return .secondary
+        case .connectionError:
+            return .red
+        }
+    }
+}

--- a/Tests/HackPanelAppTests/OperatorTimelineStoreTests.swift
+++ b/Tests/HackPanelAppTests/OperatorTimelineStoreTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import HackPanelApp
+
+@MainActor
+final class OperatorTimelineStoreTests: XCTestCase {
+    func testRecordState_insertsMostRecentFirst() {
+        let store = OperatorTimelineStore(maxEvents: 10)
+
+        let t0 = Date(timeIntervalSince1970: 1)
+        let t1 = Date(timeIntervalSince1970: 2)
+
+        store.record(state: .disconnected, at: t0)
+        store.record(state: .connected, at: t1)
+
+        XCTAssertEqual(store.events.count, 2)
+        XCTAssertEqual(store.events[0].timestamp, t1)
+        XCTAssertEqual(store.events[0].title, "Gateway connected")
+        XCTAssertEqual(store.events[1].timestamp, t0)
+        XCTAssertEqual(store.events[1].title, "Gateway disconnected")
+    }
+
+    func testRecordError_usesMessageAsDetail() {
+        let store = OperatorTimelineStore(maxEvents: 10)
+        let ts = Date(timeIntervalSince1970: 123)
+
+        store.record(errorMessage: "Cannot connect", at: ts)
+
+        XCTAssertEqual(store.events.first?.title, "Connection error")
+        XCTAssertEqual(store.events.first?.detail, "Cannot connect")
+    }
+
+    func testMaxEvents_isCapped() {
+        let store = OperatorTimelineStore(maxEvents: 2)
+        let t0 = Date(timeIntervalSince1970: 1)
+        let t1 = Date(timeIntervalSince1970: 2)
+        let t2 = Date(timeIntervalSince1970: 3)
+
+        store.record(state: .disconnected, at: t0)
+        store.record(state: .connected, at: t1)
+        store.record(errorMessage: "Boom", at: t2)
+
+        XCTAssertEqual(store.events.count, 2)
+        XCTAssertEqual(store.events[0].timestamp, t2)
+        XCTAssertEqual(store.events[1].timestamp, t1)
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #130.

Adds a minimal, read-only **Timeline** screen that records operator-relevant events from the existing `GatewayConnectionStore`:
- Connection state changes (connected/disconnected/reconnecting/auth failed)
- Connection errors (friendly message)

This gives operators a quick “what happened, when?” surface without needing a logs viewer or new gateway protocol.

## Screenshots / Screen recording (for UI changes)
N/A (new screen using existing Liquid Glass primitives).

## How to test
1. Run the app.
2. In the sidebar, open **Timeline**.
3. Toggle connectivity / use `HACKPANEL_FORCE_STATE` (DEBUG) to simulate state changes.
4. Verify new events appear (most recent at top).
5. Click **Clear** and confirm the list empties.
6. Run `swift test`.

## Risk / Rollback plan
Low risk: additive UI + isolated store. Rollback by reverting this PR.

## Accessibility impact
- Uses standard `List` rows + `ContentUnavailableView` actions.

## Test coverage
- Added unit tests for `OperatorTimelineStore` ordering + cap behavior.
- `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
