### PR TITLE
Fix: Sidebar Settings works on Connect-to-Gateway onboarding

### DIFF
--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -44,11 +44,13 @@ struct RootView: View {
                 }
                 .navigationSplitViewColumnWidth(min: 180, ideal: 220)
             } detail: {
-                if GatewayOnboardingGate.shouldShowOnboarding(
+                let shouldShowOnboarding = GatewayOnboardingGate.shouldShowOnboarding(
                     hasEverConnected: hasEverConnectedToGateway,
                     baseURL: gatewayBaseURL,
                     connectionState: gateway.state
-                ) {
+                )
+
+                if shouldShowOnboarding, (route ?? .overview) != .settings {
                     OnboardingView(
                         onOpenSettings: { route = .settings },
                         onReconnect: GatewayOnboardingGate.isBaseURLInvalid(gatewayBaseURL) ? nil : { gateway.retryNow() }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #154. The onboarding gate intentionally forces the Connect-to-Gateway screen, but it also unintentionally prevented navigating to Settings via the sidebar or the "Open Settings" button. This change allows the Settings route to bypass the onboarding gate so users can always reach Settings while disconnected.

## Screenshots / Screen recording (for UI changes)
N/A (logic-only view routing change).

## How to test
1. Fresh install / never connected (or set `hasEverConnectedToGateway=false`) with gateway disconnected.
2. App shows the Connect-to-Gateway onboarding screen.
3. Click **Settings** in the sidebar → Settings should open.
4. Click **Open Settings** on the onboarding screen → Settings should open.

## Risk / Rollback plan
Low risk: only changes routing condition around onboarding. Revert this commit to restore prior behavior.

## Accessibility impact
- None expected; ensures Settings remains reachable via sidebar (improves keyboard/VO navigation in disconnected state).

## Test coverage
- `swift test`

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
