### PR TITLE
P1: Coalesce concurrent refresh calls (refresh storm guard)

### DIFF
--- a/Tests/HackPanelAppTests/GatewayConnectionStoreCoalescingTests.swift
+++ b/Tests/HackPanelAppTests/GatewayConnectionStoreCoalescingTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import HackPanelGateway
+@testable import HackPanelApp
+
+@MainActor
+final class GatewayConnectionStoreCoalescingTests: XCTestCase {
+    func testFetchNodes_coalescesConcurrentCalls() async throws {
+        actor Counter {
+            var calls: Int = 0
+            func bump() { calls += 1 }
+            func get() -> Int { calls }
+        }
+
+        struct CountingClient: GatewayClient {
+            let counter: Counter
+
+            func fetchStatus() async throws -> GatewayStatus {
+                // Not used in this test.
+                throw URLError(.unsupportedURL)
+            }
+
+            func fetchNodes() async throws -> [NodeSummary] {
+                await counter.bump()
+                // Simulate a slow network call so concurrent callers overlap.
+                try await Task.sleep(nanoseconds: 75_000_000)
+                return []
+            }
+        }
+
+        let counter = Counter()
+        let store = GatewayConnectionStore(client: CountingClient(counter: counter))
+
+        try await withThrowingTaskGroup(of: [NodeSummary].self) { group in
+            for _ in 0..<8 {
+                group.addTask { try await store.fetchNodes() }
+            }
+
+            for try await _ in group {
+                // drain
+            }
+        }
+
+        let calls = await counter.get()
+        XCTAssertEqual(calls, 1)
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #147.

Adds lightweight request coalescing in `GatewayConnectionStore` so duplicate triggers (monitor loop + view refresh + manual retry) don’t spawn parallel `fetchStatus`/`fetchNodes` calls.

## Screenshots / Screen recording (for UI changes)
N/A.

## How to test
1. Run `swift test`.
2. (Optional) In the app, click Refresh rapidly in Nodes (and/or trigger Retry) and confirm UI stays stable while requests are in-flight.

## Risk / Rollback plan
Low risk (no protocol changes). If any unexpected behavior occurs, revert this PR to return to the previous “always fire” behavior.

## Accessibility impact
- None.

## Test coverage
- Added unit test asserting concurrent `fetchNodes()` calls coalesce to a single underlying client call.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
