### PR TITLE
Onboarding: make Open Settings primary + token reassurance

### DIFF
--- a/Sources/HackPanelApp/UI/OnboardingView.swift
+++ b/Sources/HackPanelApp/UI/OnboardingView.swift
@@ -4,14 +4,25 @@ struct OnboardingView: View {
     var onOpenSettings: () -> Void
     var onReconnect: (() -> Void)?
 
+    @FocusState private var focusOpenSettings: Bool
+
     var body: some View {
         ContentUnavailableView {
             Label("Connect HackPanel to a Gateway", systemImage: "bolt.horizontal.circle")
         } description: {
-            Text("Open Settings to configure your Gateway URL and token. Once connected, this screen will go away automatically.")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Open Settings to configure your Gateway URL and token. Once connected, this screen will go away automatically.")
+
+                Text("Your token stays local and is never displayed again.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
         } actions: {
             Button("Open Settings") { onOpenSettings() }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
                 .keyboardShortcut(",", modifiers: .command)
+                .focused($focusOpenSettings)
                 .accessibilityHint("Opens Settings so you can configure the Gateway connection")
 
             if let onReconnect {
@@ -20,6 +31,7 @@ struct OnboardingView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { focusOpenSettings = true }
     }
 }
 


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #157.

- Make **Open Settings** the primary CTA on the onboarding/connection-unconfigured screen.
- Set **Open Settings** as the default action (Return) + initial focus.
- Add a one-line reassurance that the token stays local and is never displayed again.

## Screenshots / Screen recording (for UI changes)
N/A (minor copy + button styling/focus only).

## How to test
1. Launch the app in an unconfigured/disconnected state so the onboarding screen is shown.
2. Verify **Open Settings** is visually primary.
3. Verify **Open Settings** has initial focus and pressing Return activates it.
4. Verify the reassurance copy is present and reads well in Light/Dark.

## Risk / Rollback plan
Low risk (copy + button styling/focus only). Rollback: revert this PR.

## Accessibility impact
- Open Settings is a prominent, focused action.
- Added secondary reassurance text; no new controls.

## Test coverage
- `swift test` (not run in this agent loop).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
