### PR TITLE
P1: Pause/slow auto-refresh when app inactive

### DIFF
--- a/Sources/HackPanelApp/Support/DiagnosticsFormatter.swift
+++ b/Sources/HackPanelApp/Support/DiagnosticsFormatter.swift
@@ -17,6 +17,10 @@ enum DiagnosticsFormatter {
         /// If present, indicates when the next reconnect attempt is allowed.
         var reconnectBackoffUntil: Date?
 
+        // Refresh scheduling diagnostics.
+        var isRefreshPaused: Bool
+        var lastActiveAt: Date?
+
         init(
             appVersion: String,
             appBuild: String,
@@ -27,7 +31,9 @@ enum DiagnosticsFormatter {
             connectionState: String,
             lastErrorMessage: String? = nil,
             lastErrorAt: Date? = nil,
-            reconnectBackoffUntil: Date? = nil
+            reconnectBackoffUntil: Date? = nil,
+            isRefreshPaused: Bool = false,
+            lastActiveAt: Date? = nil
         ) {
             self.appVersion = appVersion
             self.appBuild = appBuild
@@ -39,6 +45,8 @@ enum DiagnosticsFormatter {
             self.lastErrorMessage = lastErrorMessage
             self.lastErrorAt = lastErrorAt
             self.reconnectBackoffUntil = reconnectBackoffUntil
+            self.isRefreshPaused = isRefreshPaused
+            self.lastActiveAt = lastActiveAt
         }
     }
 
@@ -73,6 +81,12 @@ enum DiagnosticsFormatter {
         if let until = input.reconnectBackoffUntil {
             let remaining = max(0, Int(until.timeIntervalSince(now).rounded(.up)))
             lines.append("Reconnect backoff: \(remaining)s remaining (until \(iso8601(until)))")
+        }
+
+        lines.append("")
+        lines.append("Refresh paused: \(input.isRefreshPaused ? "Yes" : "No")")
+        if let lastActiveAt = input.lastActiveAt {
+            lines.append("Last active at: \(iso8601(lastActiveAt))")
         }
 
         return lines.joined(separator: "\n") + "\n"

--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -19,6 +19,8 @@ struct RootView: View {
     @AppStorage("gatewayBaseURL") private var gatewayBaseURL: String = GatewayDefaults.baseURLString
     @AppStorage("hasEverConnectedToGateway") private var hasEverConnectedToGateway: Bool = false
 
+    @Environment(\.scenePhase) private var scenePhase
+
     @StateObject private var gateway: GatewayConnectionStore
     @State private var route: Route? = .overview
 
@@ -83,6 +85,9 @@ struct RootView: View {
             if newValue == .connected {
                 hasEverConnectedToGateway = true
             }
+        }
+        .onChange(of: scenePhase) { _, newValue in
+            gateway.setAppActive(newValue == .active)
         }
         .environmentObject(gateway)
         .frame(minWidth: 900, minHeight: 600)

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -801,7 +801,9 @@ struct SettingsView: View {
                 connectionState: gateway.state.displayName,
                 lastErrorMessage: gateway.lastErrorMessage,
                 lastErrorAt: gateway.lastErrorAt,
-                reconnectBackoffUntil: reconnectBackoffUntil
+                reconnectBackoffUntil: reconnectBackoffUntil,
+                isRefreshPaused: gateway.isRefreshPaused,
+                lastActiveAt: gateway.lastActiveAt
             )
         )
     }

--- a/Tests/HackPanelAppTests/GatewayConnectionStoreInactiveRefreshTests.swift
+++ b/Tests/HackPanelAppTests/GatewayConnectionStoreInactiveRefreshTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import HackPanelGateway
+import HackPanelGatewayMocks
+@testable import HackPanelApp
+
+@MainActor
+final class GatewayConnectionStoreInactiveRefreshTests: XCTestCase {
+    actor SleepDriver {
+        struct SleepRequest {
+            var seconds: TimeInterval
+            var continuation: CheckedContinuation<Void, Never>
+        }
+
+        private var pending: [SleepRequest] = []
+        private var nextRequestContinuation: CheckedContinuation<TimeInterval, Never>?
+
+        func sleep(_ seconds: TimeInterval) async {
+            // Notify the test that a sleep was requested.
+            if let cont = nextRequestContinuation {
+                nextRequestContinuation = nil
+                cont.resume(returning: seconds)
+            } else {
+                // If nobody is waiting yet, enqueue a signal via pending.
+            }
+
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                pending.append(SleepRequest(seconds: seconds, continuation: cont))
+            }
+        }
+
+        func waitForNextSleepRequest() async -> TimeInterval {
+            if let first = pending.first {
+                return first.seconds
+            }
+
+            return await withCheckedContinuation { (cont: CheckedContinuation<TimeInterval, Never>) in
+                nextRequestContinuation = cont
+            }
+        }
+
+        func resumeNextSleep() {
+            guard !pending.isEmpty else { return }
+            let req = pending.removeFirst()
+            req.continuation.resume()
+        }
+
+        func pendingCount() -> Int { pending.count }
+    }
+
+    func testMonitorLoop_usesInactiveInterval_andTriggersSingleImmediateRefreshOnReactivation() async throws {
+        let driver = SleepDriver()
+
+        let tuning = GatewayConnectionStore.MonitorTuning(
+            pollIntervalSeconds: 1,
+            inactivePollIntervalSeconds: 5,
+            baseBackoffSeconds: 0.01,
+            maxBackoffSeconds: 0.01,
+            errorDedupeWindowSeconds: 0.01,
+            sleepQuantumSeconds: 10 // >= interval so each poll sleep is a single call
+        )
+
+        let store = GatewayConnectionStore(
+            client: MockGatewayClient(scenario: .demo),
+            tuning: tuning,
+            now: { Date(timeIntervalSince1970: 0) },
+            sleep: { seconds in await driver.sleep(seconds) }
+        )
+
+        store.start()
+        defer { store.stop() }
+
+        // First successful cycle should sleep at the foreground poll interval.
+        let first = await driver.waitForNextSleepRequest()
+        XCTAssertEqual(first, 1, accuracy: 0.0001)
+
+        // Make app inactive; next cycle should use inactive interval.
+        store.setAppActive(false)
+        await driver.resumeNextSleep()
+
+        let second = await driver.waitForNextSleepRequest()
+        XCTAssertEqual(second, 5, accuracy: 0.0001)
+
+        // Reactivate; the next poll should *not* sleep (immediate refresh) and then return to normal interval.
+        store.setAppActive(true)
+        await driver.resumeNextSleep()
+
+        // After reactivation, there should be no additional sleep queued immediately; we expect the loop
+        // to re-run and then request the normal foreground sleep.
+        let third = await driver.waitForNextSleepRequest()
+        XCTAssertEqual(third, 1, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #160.

When the app becomes inactive (background / not focused), the connection monitor loop should not keep polling at full speed. This PR:
- introduces an inactive polling interval (slower)
- interrupts any pending sleep when returning active
- triggers exactly one immediate refresh on reactivation (coalesced via existing in-flight guardrails)
- surfaces minimal debug fields (`isRefreshPaused`, `lastActiveAt`) for diagnostics.

## Screenshots / Screen recording (for UI changes)
N/A (behavior change only).

## How to test
1. Launch the app and connect to a gateway.
2. Leave the app running, then background it / switch focus away.
3. Confirm polling slows while inactive (no rapid refresh storms).
4. Return to the app.
5. Confirm exactly one immediate refresh happens on reactivation.
6. Run `swift test`.

## Risk / Rollback plan
Moderate-low: affects the monitor loop sleep scheduling only.
Rollback: revert this PR if refresh behavior regresses.

## Accessibility impact
- None.

## Test coverage
- Added `GatewayConnectionStoreInactiveRefreshTests`.
- `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
