### PR TITLE
P1: show refresh scheduler debug fields in Settings diagnostics

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -267,6 +267,28 @@ struct SettingsView: View {
                                 }
                             }
 
+                            Divider()
+
+                            LabeledContent("Last refresh attempt") {
+                                Text(gateway.lastRefreshAttemptAt.map { Self.uiTimestampFormatter.string(from: $0) } ?? "—")
+                            }
+
+                            LabeledContent("Last refresh result") {
+                                Text(gateway.lastRefreshResult ?? "—")
+                            }
+
+                            LabeledContent("Next scheduled refresh") {
+                                Text(gateway.nextScheduledRefreshAt.map { Self.uiTimestampFormatter.string(from: $0) } ?? "—")
+                            }
+
+                            LabeledContent("Current backoff") {
+                                if let s = gateway.currentBackoffSeconds {
+                                    Text("\(String(format: "%.1f", s))s")
+                                } else {
+                                    Text("—")
+                                }
+                            }
+
                             Button {
                                 copyToPasteboard(settingsSummaryText)
                                 copiedSummaryAt = Date()


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why

## Screenshots / Screen recording (for UI changes)

## How to test
1.

## Risk / Rollback plan

## Accessibility impact
- 

## Test coverage
- 

## Migration notes
- 

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.

## What / Why
Fixes #166.

Settings → Diagnostics now shows refresh-scheduler debug fields (last attempt/result, next scheduled refresh, current backoff) so operators can debug refresh behavior without spelunking logs.

## Screenshots / Screen recording (for UI changes)
N/A (settings diagnostics read-only fields).

## How to test
1. Run the app and open **Settings → Diagnostics**.
2. Observe the new refresh scheduler fields.
3. Trigger a reconnect/refresh (e.g. **Retry Now**) and verify the timestamps/fields update.
4. Run `swift test`.

## Risk / Rollback plan
Low. UI-only plus a few published debug fields on `GatewayConnectionStore`. Revert this PR if it causes any unexpected state/UI updates.

## Accessibility impact
- None expected (read-only fields).

## Test coverage
- `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
