### PR TITLE
P0: Show gateway version/build in Settings Test connection

### DIFF
--- a/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
+++ b/Sources/HackPanelApp/Connection/GatewayConnectionStore.swift
@@ -234,10 +234,10 @@ final class GatewayConnectionStore: ObservableObject {
     /// Perform a one-shot status request against the currently-configured Gateway.
     ///
     /// Used by Settings "Test connection" without altering the monitor loop/state.
-    func testConnection() async throws {
+    func testConnection() async throws -> GatewayStatus {
         log("settings: testConnection")
         lastHealthCheckAt = Date()
-        _ = try await client.fetchStatus()
+        return try await client.fetchStatus()
     }
 
     private func runMonitorLoop() async {

--- a/Sources/HackPanelGateway/Client/GatewayPayloads.swift
+++ b/Sources/HackPanelGateway/Client/GatewayPayloads.swift
@@ -6,6 +6,11 @@ import Foundation
 struct StatusPayload: Codable, Sendable {
     var ok: Bool?
     var version: String?
+
+    // Best-effort metadata (not guaranteed to exist on the server).
+    var build: String?
+    var commit: String?
+
     var uptimeSeconds: Double?
     var uptimeMs: Double?
 }

--- a/Sources/HackPanelGateway/Client/LiveGatewayClient.swift
+++ b/Sources/HackPanelGateway/Client/LiveGatewayClient.swift
@@ -34,6 +34,8 @@ public struct LiveGatewayClient: GatewayClient {
         return GatewayStatus(
             ok: payload.ok ?? true,
             version: payload.version,
+            build: payload.build,
+            commit: payload.commit,
             uptimeSeconds: payload.uptimeSeconds ?? payload.uptimeMs.map { $0 / 1000.0 }
         )
     }

--- a/Sources/HackPanelGateway/Models/GatewayStatus.swift
+++ b/Sources/HackPanelGateway/Models/GatewayStatus.swift
@@ -2,12 +2,30 @@ import Foundation
 
 public struct GatewayStatus: Codable, Sendable, Equatable {
     public var ok: Bool
+
+    /// Gateway version string (semver-ish). Shape depends on the server.
     public var version: String?
+
+    /// Optional build/commit metadata when the server exposes it.
+    ///
+    /// The upstream Gateway status payload is not strictly specified, so we decode these
+    /// best-effort and treat them as purely informational.
+    public var build: String?
+    public var commit: String?
+
     public var uptimeSeconds: Double?
 
-    public init(ok: Bool, version: String? = nil, uptimeSeconds: Double? = nil) {
+    public init(
+        ok: Bool,
+        version: String? = nil,
+        build: String? = nil,
+        commit: String? = nil,
+        uptimeSeconds: Double? = nil
+    ) {
         self.ok = ok
         self.version = version
+        self.build = build
+        self.commit = commit
         self.uptimeSeconds = uptimeSeconds
     }
 }

--- a/Sources/HackPanelGatewayMocks/MockGatewayClient.swift
+++ b/Sources/HackPanelGatewayMocks/MockGatewayClient.swift
@@ -16,9 +16,9 @@ public struct MockGatewayClient: GatewayClient {
     public func fetchStatus() async throws -> GatewayStatus {
         switch scenario {
         case .demo:
-            return GatewayStatus(ok: true, version: "OpenClaw 2026.x", uptimeSeconds: 12_345)
+            return GatewayStatus(ok: true, version: "OpenClaw 2026.x", build: "dev", commit: "(mock)", uptimeSeconds: 12_345)
         case .gatewayDown:
-            return GatewayStatus(ok: false, version: nil, uptimeSeconds: nil)
+            return GatewayStatus(ok: false, version: nil, build: nil, commit: nil, uptimeSeconds: nil)
         }
     }
 


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Extends Settings → **Test connection** success state to show what we connected to (Gateway **version** + **build/commit** when available).
- Helps operators verify they’re pointed at the intended Gateway without adding any new “About” surface.

## Screenshots / Screen recording (for UI changes)
- n/a (small caption-only addition under the Test connection result; no layout changes outside Settings).

## How to test
1. Run the app and open **Settings**.
2. Click **Test connection**.
3. On success, verify:
   - Test result shows **Connection OK**
   - A **Connected to:** section appears with Version + Build (or “Not available”).
4. Toggle Auto-apply ON/OFF and repeat to confirm both paths still test the correct config.
5. `swift test`

## Risk / Rollback plan
- Low risk: only affects Settings Test connection UI + best-effort decoding of optional status metadata.
- Rollback: revert this PR.

## Accessibility impact
- Adds additional caption text; no new controls.

## Test coverage
- `swift test` (existing test suite).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.