### PR TITLE
Nodes: sort menu (Online first / Name)

### DIFF
--- a/Tests/HackPanelAppTests/NodesSortingTests.swift
+++ b/Tests/HackPanelAppTests/NodesSortingTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import HackPanelGateway
+@testable import HackPanelApp
+
+final class NodesSortingTests: XCTestCase {
+    func testSort_onlineFirst_ordersByStateThenNameThenId() {
+        let nodes: [NodeSummary] = [
+            .init(id: "3", name: "Bravo", state: .offline),
+            .init(id: "2", name: "alpha", state: .online),
+            .init(id: "1", name: "Alpha", state: .online),
+            .init(id: "4", name: "Charlie", state: .unknown),
+        ]
+
+        let sorted = NodesViewModel.sort(nodes, by: .onlineFirst)
+
+        XCTAssertEqual(sorted.map(\.id), [
+            // online: name (case-insensitive) then id
+            "1", "2",
+            // offline
+            "3",
+            // unknown
+            "4",
+        ])
+    }
+
+    func testSort_name_ordersByNameThenStateThenId_forStability() {
+        let nodes: [NodeSummary] = [
+            .init(id: "b", name: "Alpha", state: .offline),
+            .init(id: "a", name: "alpha", state: .online),
+            .init(id: "c", name: "Bravo", state: .online),
+        ]
+
+        let sorted = NodesViewModel.sort(nodes, by: .name)
+
+        XCTAssertEqual(sorted.map(\.id), [
+            // alpha rows grouped first (case-insensitive), then stable by state then id
+            "a", "b",
+            "c",
+        ])
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #152.

Adds a small sort control to the Nodes list so operators can switch between:
- **Online first** (default)
- **Name**

Selection is persisted via AppStorage/UserDefaults.

## Screenshots / Screen recording (for UI changes)
N/A (small header menu).

## How to test
1. Run the app and open **Nodes**.
2. Use the new **Sort** menu:
   - Set to **Online first** and confirm online nodes appear before offline/unknown.
   - Set to **Name** and confirm nodes are sorted alphabetically.
3. Quit + relaunch: confirm the sort option persists.
4. Run `swift test`.

## Risk / Rollback plan
Low risk (client-side sorting + small UI control). Revert this PR to return to the previous default sort.

## Accessibility impact
- Uses a standard SwiftUI Menu + Picker; should be keyboard accessible.

## Test coverage
- Added unit tests for sorting comparator logic (`NodesSortingTests`).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
