### PR TITLE
Docs: XcodeBuildMCP setup notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@
 - Run `HackPanelApp`.
 - Tests: `swift test`.
 
+### Optional: XcodeBuildMCP (agent build/test feedback loop)
+If you want an AI coding agent to run Xcode builds/tests and return structured failures, set up Sentry’s **XcodeBuildMCP**:
+- `Docs/Tooling/XcodeBuildMCP.md`
+
 ### SPM sanity check (matches CI)
 Run the same commands CI runs:
 

--- a/Docs/Tooling/XcodeBuildMCP.md
+++ b/Docs/Tooling/XcodeBuildMCP.md
@@ -1,0 +1,74 @@
+# XcodeBuildMCP (Sentry) — setup (optional)
+
+Goal: enable an AI coding agent to run **repeatable** `xcodebuild`/tests and return structured failures (without “works on my machine” guesswork).
+
+Upstream: https://github.com/getsentry/XcodeBuildMCP
+
+## Install
+
+### Option A — Homebrew (recommended)
+
+```bash
+brew tap getsentry/xcodebuildmcp
+brew install xcodebuildmcp
+
+# sanity
+xcodebuildmcp --help
+```
+
+### Option B — npx (no global install)
+
+```bash
+# sanity
+npx -y xcodebuildmcp@latest --help
+```
+
+## Configure as an MCP server
+
+### Codex CLI
+
+```bash
+codex mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@latest mcp
+```
+
+Or in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.XcodeBuildMCP]
+command = "npx"
+args = ["-y", "xcodebuildmcp@latest", "mcp"]
+```
+
+### Claude Code
+
+```bash
+claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@latest mcp
+```
+
+### Cursor
+
+Add `.cursor/mcp.json` at the workspace root:
+
+```json
+{
+  "mcpServers": {
+    "XcodeBuildMCP": {
+      "command": "npx",
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"]
+    }
+  }
+}
+```
+
+## Smoke test (HackPanel)
+
+Once installed + configured, use your agent client to request an Xcode build/test of this workspace.
+
+Suggested command targets (match what we run locally/CI):
+- Open `Package.swift` in Xcode, build `HackPanelApp`
+- CLI tests: `swift test`
+
+## Notes / guardrails
+- Don’t commit any machine-local MCP config (e.g. `~/.codex/config.toml`) into this repo.
+- Prefer least-privilege defaults.
+- If the tool requires any credentials/config, keep them out of git and document where they should live (e.g. Keychain / user config directory).


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #169.

Adds a minimal doc for installing/configuring Sentry’s **XcodeBuildMCP** and links it from `CONTRIBUTING.md`, so agents/contributors can set up an Xcode build/test feedback loop without committing machine-local config.

## Screenshots / Screen recording (for UI changes)
N/A.

## How to test
1. Open `Docs/Tooling/XcodeBuildMCP.md` and verify the instructions match upstream.
2. Verify `CONTRIBUTING.md` links to the doc.

## Risk / Rollback plan
No runtime impact (docs-only). Roll back by reverting this commit.

## Accessibility impact
- None.

## Test coverage
- N/A (docs-only).

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
