### PR TITLE
Logs screen: show recent gateway logs + copy

### DIFF
--- a/Sources/HackPanelApp/UI/LogsView.swift
+++ b/Sources/HackPanelApp/UI/LogsView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#endif
+
+struct LogsView: View {
+    @EnvironmentObject private var connection: GatewayConnectionStore
+
+    private let onOpenSettings: (() -> Void)?
+
+    init(onOpenSettings: (() -> Void)? = nil) {
+        self.onOpenSettings = onOpenSettings
+    }
+
+    private var logsText: String {
+        let lines = connection.recentLogLines
+        guard !lines.isEmpty else {
+            return ""
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private var shouldShowGatewayUnavailableState: Bool {
+        connection.state != .connected && connection.recentLogLines.isEmpty
+    }
+
+    private var gatewayUnavailableTitle: String {
+        connection.state == .authFailed ? "Authentication required" : "Gateway unavailable"
+    }
+
+    private var gatewayUnavailableIcon: String {
+        connection.state == .authFailed ? "lock.slash" : "wifi.exclamationmark"
+    }
+
+    private var gatewayUnavailableDescription: String {
+        switch connection.state {
+        case .authFailed:
+            return "Update your gateway token in Settings, then reconnect."
+        case .disconnected, .reconnecting:
+            return "Check your gateway URL in Settings, then reconnect."
+        case .connected:
+            return ""
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
+            HStack {
+                Text("Logs")
+                    .font(.title2.weight(.semibold))
+
+                Spacer()
+
+                Button {
+                    copyToPasteboard(logsText)
+                } label: {
+                    Label("Copy visible logs", systemImage: "doc.on.doc")
+                }
+                .disabled(connection.recentLogLines.isEmpty)
+            }
+
+            if shouldShowGatewayUnavailableState {
+                GlassCard {
+                    ContentUnavailableView {
+                        Label(gatewayUnavailableTitle, systemImage: gatewayUnavailableIcon)
+                    } description: {
+                        Text(gatewayUnavailableDescription)
+                    } actions: {
+                        if let onOpenSettings {
+                            Button("Open Settings") { onOpenSettings() }
+                        }
+
+                        Button("Reconnect") {
+                            connection.retryNow()
+                        }
+                        .accessibilityHint(Text("Retries connecting to the gateway"))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else if connection.recentLogLines.isEmpty {
+                GlassCard {
+                    ContentUnavailableView {
+                        Label("No logs yet", systemImage: "doc.text")
+                    } description: {
+                        Text("Recent gateway logs will appear here after the app makes a connection attempt.")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else {
+                GlassSurface {
+                    ScrollView {
+                        Text(logsText)
+                            .textSelection(.enabled)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    }
+                    .frame(minHeight: 220)
+                }
+            }
+        }
+        .padding(AppTheme.Layout.pagePadding)
+    }
+
+    private func copyToPasteboard(_ text: String) {
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
+    }
+}

--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -13,6 +13,7 @@ struct RootView: View {
         case nodes
         case providers
         case timeline
+        case logs
         case settings
     }
 
@@ -47,6 +48,7 @@ struct RootView: View {
                     NavigationLink("Nodes", value: Route.nodes)
                     NavigationLink("Providers", value: Route.providers)
                     NavigationLink("Timeline", value: Route.timeline)
+                    NavigationLink("Logs", value: Route.logs)
                     NavigationLink("Settings", value: Route.settings)
                 }
                 .navigationSplitViewColumnWidth(min: 180, ideal: 220)
@@ -72,6 +74,8 @@ struct RootView: View {
                         ProvidersView(onOpenSettings: { route = .settings })
                     case .timeline:
                         TimelineView(onOpenSettings: { route = .settings })
+                    case .logs:
+                        LogsView(onOpenSettings: { route = .settings })
                     case .settings:
                         SettingsView(gateway: gateway)
                     }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Fixes #28.

Adds a minimal **Logs** screen to the sidebar that shows the app's best-effort recent gateway log lines (as captured by `GatewayConnectionStore`). Includes a **Copy visible logs** action, plus the standard disconnected/auth-failed empty state with **Open Settings** and **Reconnect** actions.

## Screenshots / Screen recording (for UI changes)
N/A (simple new screen; no complex visuals).

## How to test
1. Run the app.
2. Navigate to **Logs** in the sidebar.
3. If disconnected, verify you see **Open Settings** (when available) + **Reconnect**.
4. After a connection attempt, verify recent log lines appear in monospaced text.
5. Click **Copy visible logs** and confirm pasteboard contains the visible log text.
6. Run `swift test`.

## Risk / Rollback plan
Low risk: additive UI route + view only. Roll back by reverting this PR.

## Accessibility impact
- Uses `ContentUnavailableView` labels/descriptions.
- Copy button has a clear label and is disabled when there are no logs.

## Test coverage
- `swift test`

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.