### PR TITLE
Nodes: basic search filter

### DIFF
--- a/Tests/HackPanelAppTests/NodesFilteringTests.swift
+++ b/Tests/HackPanelAppTests/NodesFilteringTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import HackPanelGateway
+@testable import HackPanelApp
+
+final class NodesFilteringTests: XCTestCase {
+    func testFilter_emptyQuery_returnsAllNodes() {
+        let nodes: [NodeSummary] = [
+            .init(id: "abc", name: "Alpha", state: .online),
+            .init(id: "def", name: "Bravo", state: .offline),
+        ]
+
+        XCTAssertEqual(NodesViewModel.filter(nodes, query: "").map(\.id), ["abc", "def"])
+        XCTAssertEqual(NodesViewModel.filter(nodes, query: "   ").map(\.id), ["abc", "def"])
+    }
+
+    func testFilter_matchesNameOrId_caseInsensitive_contains() {
+        let nodes: [NodeSummary] = [
+            .init(id: "node-123", name: "Kitchen Pi", state: .online),
+            .init(id: "NODE-999", name: "Garage", state: .offline),
+        ]
+
+        XCTAssertEqual(NodesViewModel.filter(nodes, query: "kitch").map(\.id), ["node-123"])
+        XCTAssertEqual(NodesViewModel.filter(nodes, query: "999").map(\.id), ["NODE-999"])
+        XCTAssertEqual(NodesViewModel.filter(nodes, query: "node-").map(\.id), ["node-123", "NODE-999"])
+    }
+}


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Adds a simple in-view search filter to the Nodes list (Issue #164). Users can filter by node **name or id** using a case-insensitive contains match.

## Screenshots / Screen recording (for UI changes)
N/A (standard macOS `.searchable` field).

## How to test
1. Run the app and open **Nodes**.
2. Use the search field and type part of a node name or id.
3. Confirm the list filters live; clear the query and confirm the full list returns.
4. Type a query that matches nothing and confirm the "No matching nodes" empty state appears.

## Risk / Rollback plan
Low risk; view-only filtering on existing in-memory node list. Rollback by reverting this commit.

## Accessibility impact
- Uses SwiftUI `.searchable` (keyboard accessible).
- Adds an explicit "Clear search" action when no results.

## Test coverage
- Adds `NodesFilteringTests` covering empty query passthrough + name/id case-insensitive contains.

## Migration notes
None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
