### PR TITLE
Settings: show draft dirty state + disable no-op Apply

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -74,6 +74,18 @@ struct SettingsView: View {
         return df
     }()
 
+    private var normalizedDraftBaseURL: String {
+        draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var normalizedDraftToken: String {
+        draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isDraftDirty: Bool {
+        normalizedDraftBaseURL != gatewayBaseURL || normalizedDraftToken != gatewayToken
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             Form {
@@ -186,7 +198,11 @@ struct SettingsView: View {
                             Button("Apply & Reconnect") {
                                 applyAndReconnect(userInitiated: true)
                             }
-                            .disabled(baseURLValidationMessage(for: draftBaseURL) != nil || tokenValidationMessage(for: draftToken) != nil)
+                            .disabled(
+                                !isDraftDirty ||
+                                    baseURLValidationMessage(for: draftBaseURL) != nil ||
+                                    tokenValidationMessage(for: draftToken) != nil
+                            )
                         }
 
                         Button("Test connection") {
@@ -209,6 +225,12 @@ struct SettingsView: View {
 
                         Spacer()
                     }
+
+                    Text(isDraftDirty ? "Draft has changes" : "No changes")
+                        .font(.caption)
+                        .foregroundStyle(isDraftDirty ? .secondary : .secondary)
+                        .accessibilityLabel(isDraftDirty ? "Draft has changes" : "No changes")
+                        .accessibilityHint("Indicates whether the draft settings differ from the applied settings")
 
                     if isTestingConnection {
                         Text("Testing connection…")
@@ -627,9 +649,7 @@ struct SettingsView: View {
 
         // Avoid re-applying if nothing changed (unless explicitly forced).
         if !force {
-            let trimmedBaseURL = draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-            let trimmedToken = draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedBaseURL == gatewayBaseURL && trimmedToken == gatewayToken {
+            if !isDraftDirty {
                 return
             }
         }

--- a/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
+++ b/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
@@ -26,4 +26,29 @@ final class SettingsViewRenderingRegressionTests: XCTestCase {
             "Expected SettingsView to contain the 'Token' label"
         )
     }
+
+    func testSettingsSource_containsDraftDirtyStateAndDisablesNoOpApply() throws {
+        let settingsViewPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // .../Tests/HackPanelAppTests
+            .deletingLastPathComponent() // .../Tests
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent("Sources/HackPanelApp/UI/SettingsView.swift")
+
+        let source = try String(contentsOf: settingsViewPath, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("isDraftDirty"),
+            "Expected SettingsView to define an isDraftDirty flag"
+        )
+
+        XCTAssertTrue(
+            source.contains("Draft has changes") && source.contains("No changes"),
+            "Expected SettingsView to render draft dirty-state text"
+        )
+
+        XCTAssertTrue(
+            source.contains("!isDraftDirty"),
+            "Expected SettingsView to use isDraftDirty to disable no-op applies"
+        )
+    }
 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Implements #187.
- Adds a draft dirty-state indicator ("Draft has changes" / "No changes") based on comparing draft values vs persisted applied values.
- Disables the manual **Apply & Reconnect** button when there are no draft changes (prevents no-op applies).

## Screenshots / Screen recording (for UI changes)
N/A (small label + disable state only).

## How to test
1. Run the app and open Settings.
2. With Auto-apply OFF:
   - With no edits, confirm Apply & Reconnect is disabled and label shows "No changes".
   - Edit Gateway URL or Token; confirm label shows "Draft has changes" and Apply & Reconnect becomes enabled.
3. Confirm `swift test` passes.

## Risk / Rollback plan
Low risk; contained to SettingsView state/logic. Revert this PR to restore previous behavior.

## Accessibility impact
- Adds an accessible label/hint for the dirty-state indicator.

## Test coverage
- Adds a lightweight source regression test asserting dirty-state strings + `isDraftDirty` usage.

## Migration notes
None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
