### PR TITLE
Settings: require token for Apply/Test

### DIFF
--- a/Sources/HackPanelApp/GatewaySettingsValidator.swift
+++ b/Sources/HackPanelApp/GatewaySettingsValidator.swift
@@ -13,8 +13,10 @@ enum GatewaySettingsValidator {
     static func validateToken(_ raw: String) -> Result<String, ValidationError> {
         let trimmed = normalizeToken(raw)
 
-        // Empty token is allowed (gateway may not require auth).
-        guard !trimmed.isEmpty else { return .success("") }
+        // Token is required for Settings Apply/Test to avoid confusing no-op connection attempts.
+        guard !trimmed.isEmpty else {
+            return .failure(.init(message: "Token is required."))
+        }
 
         // Reject internal whitespace/newlines (common copy/paste failure mode).
         if trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -166,6 +166,7 @@ struct SettingsView: View {
                     LabeledContent("Token") {
                         SecureField("", text: $draftToken)
                             .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("settings.gatewayToken")
                             .onChange(of: draftToken) { _, newValue in
                                 hasEditedToken = true
 
@@ -192,7 +193,11 @@ struct SettingsView: View {
                         Button("Test connection") {
                             runTestConnection()
                         }
-                        .disabled(isTestingConnection || baseURLValidationMessage(for: draftBaseURL) != nil)
+                        .disabled(
+                            isTestingConnection
+                                || baseURLValidationMessage(for: draftBaseURL) != nil
+                                || tokenValidationMessage(for: draftToken) != nil
+                        )
 
                         Button("Retry Now") {
                             gateway.retryNow()
@@ -246,6 +251,7 @@ struct SettingsView: View {
 
                     if let tokenValidationError, hasEditedToken {
                         Text(tokenValidationError)
+                            .accessibilityIdentifier("settings.gatewayToken.error")
                             .font(.caption)
                             .foregroundStyle(.red)
                     }
@@ -256,7 +262,7 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
 
-                    Text("HackPanel connects to the OpenClaw Gateway WebSocket RPC endpoint (same port as HTTP; default 18789). Token is optional unless your gateway requires it.")
+                    Text("HackPanel connects to the OpenClaw Gateway WebSocket RPC endpoint (same port as HTTP; default 18789). Token is required to Apply/Test.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -386,6 +392,12 @@ struct SettingsView: View {
                 let p = profiles.activeProfile
                 if draftBaseURL.isEmpty { draftBaseURL = p.baseURLString }
                 if draftToken.isEmpty { draftToken = profiles.token(for: p.id) }
+
+                // Prime validation so required fields show inline errors immediately.
+                validationError = baseURLValidationMessage(for: draftBaseURL)
+                tokenValidationError = tokenValidationMessage(for: draftToken)
+                hasEditedBaseURL = true
+                hasEditedToken = true
             }
             .onChange(of: gatewayAutoApply) { _, _ in
                 // If user toggles auto-apply ON while dirty, apply soon.

--- a/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
+++ b/Tests/HackPanelAppTests/GatewaySettingsValidatorTests.swift
@@ -63,14 +63,9 @@ final class GatewaySettingsValidatorTests: XCTestCase {
         XCTAssertFailure(GatewaySettingsValidator.validateBaseURL("http://127.0.0.1:18789#frag"))
     }
 
-    func testValidateToken_allowsEmptyToken() {
-        let result = GatewaySettingsValidator.validateToken("")
-        switch result {
-        case .success(let token):
-            XCTAssertEqual(token, "")
-        case .failure(let error):
-            XCTFail("Expected success, got failure: \(error.message)")
-        }
+    func testValidateToken_rejectsEmptyToken() {
+        XCTAssertTokenFailure(GatewaySettingsValidator.validateToken(""))
+        XCTAssertTokenFailure(GatewaySettingsValidator.validateToken("   \n"))
     }
 
     func testValidateToken_trimsLeadingAndTrailingWhitespace() {


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Require a non-empty Gateway token before allowing **Apply & Reconnect** or **Test connection**.
- Prevents confusing “nothing happened” attempts when auth is required.

## Screenshots / Screen recording (for UI changes)
- N/A (simple inline validation + button gating).

## How to test
1. Open Settings.
2. Clear Token.
   - Verify an inline error is shown and Apply/Test are disabled.
3. Enter a non-empty token.
   - Verify error clears and Apply/Test become enabled (subject to URL validity).
4. Run `swift test`.

## Risk / Rollback plan
- Low. Reverts cleanly by restoring prior token validation rules.

## Accessibility impact
- Added stable accessibility identifiers:
  - `settings.gatewayToken`
  - `settings.gatewayToken.error`

## Test coverage
- Updated `GatewaySettingsValidatorTests` to cover empty/whitespace-only tokens as invalid.

## Migration notes
- Users without an existing stored token will now need to enter one before Apply/Test.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
