### PR TITLE
Settings: inline help + error a11y identifiers

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -78,17 +78,6 @@ struct SettingsView: View {
         return df
     }()
 
-    private var normalizedDraftBaseURL: String {
-        draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var normalizedDraftToken: String {
-        draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isDraftDirty: Bool {
-        normalizedDraftBaseURL != gatewayBaseURL || normalizedDraftToken != gatewayToken
-    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -166,7 +155,6 @@ struct SettingsView: View {
                     LabeledContent("Gateway URL") {
                         TextField("", text: $draftBaseURL)
                             .textFieldStyle(.roundedBorder)
-                            .help("Example: \(GatewayDefaults.baseURLString). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
                             .onChange(of: draftBaseURL) { _, newValue in
                                 hasEditedBaseURL = true
                                 validationError = baseURLValidationMessage(for: newValue)
@@ -178,6 +166,11 @@ struct SettingsView: View {
                                 }
                             }
                     }
+
+                    Text("Format: http(s)://host[:port] (example: \(GatewayDefaults.baseURLString)). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
+                        .accessibilityIdentifier("settings.gatewayBaseURL.help")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
 
                     LabeledContent("Token") {
                         SecureField("", text: $draftToken)
@@ -197,6 +190,11 @@ struct SettingsView: View {
                                 scheduleAutoApplyIfNeeded()
                             }
                     }
+
+                    Text("Get this from your OpenClaw Gateway UI. Token is required for Apply/Test.")
+                        .accessibilityIdentifier("settings.gatewayToken.help")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
 
                     HStack {
                         if !gatewayAutoApply {
@@ -290,6 +288,7 @@ struct SettingsView: View {
 
                     if let validationError, hasEditedBaseURL {
                         Text(validationError)
+                            .accessibilityIdentifier("settings.gatewayBaseURL.error")
                             .font(.caption)
                             .foregroundStyle(.red)
                     }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Adds inline help text under Settings → Gateway URL / Token fields (instead of relying on tooltip-only help), plus stable accessibility identifiers for help/error text.

This makes the screen more self-service and reduces confusion around required URL/token format.

## Screenshots / Screen recording (for UI changes)
- (not captured in this PR)

## How to test
1. Open Settings.
2. Verify inline help appears under “Gateway URL” and “Token”.
3. Enter an invalid URL and confirm the error renders (and has a stable a11y id).
4. Run `swift test`.

## Risk / Rollback plan
Low risk (copy/layout only). Revert commit if layout regression is reported.

## Accessibility impact
- Adds accessibility identifiers for UI test stability.

## Test coverage
- Existing `swift test` suite.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
