### PR TITLE
Settings: require token for Apply/Test (always include validated token)

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -78,17 +78,7 @@ struct SettingsView: View {
         return df
     }()
 
-    private var normalizedDraftBaseURL: String {
-        draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var normalizedDraftToken: String {
-        draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isDraftDirty: Bool {
-        normalizedDraftBaseURL != gatewayBaseURL || normalizedDraftToken != gatewayToken
-    }
+    // (Draft dirty-state computed below via GatewaySettingsDraft.differs(fromApplied:))
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -851,7 +841,8 @@ struct SettingsView: View {
         gatewayToken = trimmedToken
 
         // Apply immediately to the live connection store.
-        let cfg = GatewayConfiguration(baseURL: url, token: trimmedToken.isEmpty ? nil : trimmedToken)
+        // Token is required by validation, so always include it in the configuration.
+        let cfg = GatewayConfiguration(baseURL: url, token: trimmedToken)
         gateway.updateClient(LiveGatewayClient(configuration: cfg))
 
         // Kick the connection loop immediately so users get fast feedback.
@@ -903,7 +894,8 @@ struct SettingsView: View {
                     status = try await gateway.testConnection()
                 } else {
                     // Auto-apply OFF: explicitly test the *draft* values without persisting/applying.
-                    let cfg = GatewayConfiguration(baseURL: url, token: token.isEmpty ? nil : token)
+                    // Token is required by validation, so always include it in the configuration.
+                    let cfg = GatewayConfiguration(baseURL: url, token: token)
                     let client = LiveGatewayClient(configuration: cfg)
                     status = try await client.fetchStatus()
                 }


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
Closes #189.

Settings already validates that Token is required for Apply/Test; this PR makes the code path consistent by always passing the validated token into `GatewayConfiguration` (removes the legacy `token.isEmpty ? nil` fallback).

## Screenshots / Screen recording (for UI changes)
N/A (no UI layout changes).

## How to test
1. Run `swift test`.
2. In the app, clear Token → Apply/Test are disabled and an inline error is shown.
3. Enter a non-empty Token → Apply/Test re-enable.

## Risk / Rollback plan
Low risk (only affects token propagation after validation). Revert this PR if any unexpected auth behavior occurs.

## Accessibility impact
- None.

## Test coverage
- Existing `GatewaySettingsValidatorTests` cover required token behavior.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.
