### PR TITLE
Fix SettingsView build break (duplicate isDraftDirty)

### DIFF
--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -78,18 +78,6 @@ struct SettingsView: View {
         return df
     }()
 
-    private var normalizedDraftBaseURL: String {
-        draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var normalizedDraftToken: String {
-        draftToken.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isDraftDirty: Bool {
-        normalizedDraftBaseURL != gatewayBaseURL || normalizedDraftToken != gatewayToken
-    }
-
     var body: some View {
         ZStack(alignment: .bottom) {
             Form {


### PR DESCRIPTION
> Reviewers: see [Docs/PR_REVIEW.md](../Docs/PR_REVIEW.md) for the standard checklist and PR-comment template.

## Reviewer loop (required)
- [ ] When this PR is ready for feedback (CI green / buildable), add label **`needs-review`** to trigger the automated `hackpanel-reviewer` pass.
  - Reviewer will respond by setting either **`ok-to-merge`** or **`review-feedback`** and removing `needs-review`.
  - If you can’t add labels, ping `#hackpanel-manager`.

## What / Why
- Fixes a compile failure in `SettingsView` caused by an accidental duplicate `isDraftDirty` computed property.
- Keeps the newer `GatewaySettingsDraft`-based dirty-state logic and removes the older redundant normalized-string implementation.

## Screenshots / Screen recording (for UI changes)
- N/A (no UI change).

## How to test
1. `swift test`

## Risk / Rollback plan
- Low risk: removes dead/duplicate code path; rollback by reverting this commit.

## Accessibility impact
- None.

## Test coverage
- Existing `SettingsViewRenderingRegressionTests` + full suite via `swift test`.

## Migration notes
- None.

## Security / Secrets check
- [ ] I confirm this PR does **not** add secrets/tokens/PII to the repo/logs/fixtures.