### PR TITLE
Fix Settings tab blank screen

### DIFF
--- a/Sources/HackPanelApp/UI/RootView.swift
+++ b/Sources/HackPanelApp/UI/RootView.swift
@@ -77,9 +77,7 @@ struct RootView: View {
                     case .logs:
                         LogsView(onOpenSettings: { route = .settings })
                     case .settings:
-                        NavigationStack {
-                            SettingsView(gateway: gateway)
-                        }
+                        SettingsView(gateway: gateway)
                     }
                 }
             }

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -305,6 +305,35 @@ struct SettingsView: View {
                     Text("HackPanel connects to the OpenClaw Gateway WebSocket RPC endpoint (same port as HTTP; default 18789). Token is required to Apply/Test.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    if gateway.state != .connected {
+                        GlassSurface {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Not connected to Gateway")
+                                    .font(.subheadline.weight(.semibold))
+
+                                Text(gatewayBaseURL)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+
+                                if let msg = gateway.lastErrorMessage, !msg.isEmpty {
+                                    Text(msg)
+                                        .font(.caption)
+                                        .foregroundStyle(.red)
+                                        .textSelection(.enabled)
+                                } else {
+                                    Text("Start the OpenClaw Gateway and verify the URL/token.")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                        }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Gateway connection error")
+                    }
                 }
 
                 Section("Diagnostics") {

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -318,7 +318,7 @@ struct SettingsView: View {
                                     .textSelection(.enabled)
 
                                 if let msg = gateway.lastErrorMessage, !msg.isEmpty {
-                                    Text(msg)
+                                    Text(DiagnosticsFormatter.redactSecrets(in: msg, gatewayToken: gatewayToken))
                                         .font(.caption)
                                         .foregroundStyle(.red)
                                         .textSelection(.enabled)
@@ -350,7 +350,8 @@ struct SettingsView: View {
                             }
 
                             LabeledContent("Last error") {
-                                Text(gateway.lastErrorMessage ?? "(none)")
+                                let msg = gateway.lastErrorMessage ?? "(none)"
+                                Text(DiagnosticsFormatter.redactSecrets(in: msg, gatewayToken: gatewayToken))
                                     .textSelection(.enabled)
                                     .accessibilityIdentifier("settings.diagnostics.lastError")
                             }

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -434,6 +434,7 @@ struct SettingsView: View {
                 }
             }
             .padding(24)
+            .navigationTitle("Settings")
             .onAppear {
                 // Initialize drafts from the active profile.
                 let p = profiles.activeProfile

--- a/Sources/HackPanelApp/UI/SettingsView.swift
+++ b/Sources/HackPanelApp/UI/SettingsView.swift
@@ -155,7 +155,7 @@ struct SettingsView: View {
                     LabeledContent("Gateway URL") {
                         TextField("", text: $draftBaseURL)
                             .textFieldStyle(.roundedBorder)
-                            .help("Example: \(GatewayDefaults.baseURLString). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
+                            .help("Example: http(s)://your-gateway-host:\(GatewayDefaults.defaultPort). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
                             .onChange(of: draftBaseURL) { _, newValue in
                                 hasEditedBaseURL = true
                                 validationError = baseURLValidationMessage(for: newValue)
@@ -511,7 +511,7 @@ struct SettingsView: View {
                     LabeledContent("Gateway URL") {
                         TextField("", text: $newProfileBaseURL)
                             .textFieldStyle(.roundedBorder)
-                            .help("Example: \(GatewayDefaults.baseURLString). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
+                            .help("Example: http(s)://your-gateway-host:\(GatewayDefaults.defaultPort). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
                             .onChange(of: newProfileBaseURL) { _, newValue in
                                 newProfileBaseURLError = baseURLValidationMessage(for: newValue)
                             }
@@ -594,7 +594,7 @@ struct SettingsView: View {
                     LabeledContent("Gateway URL") {
                         TextField("", text: $editProfileBaseURL)
                             .textFieldStyle(.roundedBorder)
-                            .help("Example: \(GatewayDefaults.baseURLString). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
+                            .help("Example: http(s)://your-gateway-host:\(GatewayDefaults.defaultPort). If you omit a port, HackPanel assumes :\(GatewayDefaults.defaultPort).")
                             .onChange(of: editProfileBaseURL) { _, newValue in
                                 editProfileBaseURLError = baseURLValidationMessage(for: newValue)
                             }

--- a/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
+++ b/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
@@ -102,8 +102,8 @@ final class SettingsViewRenderingRegressionTests: XCTestCase {
         )
 
         XCTAssertTrue(
-            source.contains("gateway.lastErrorMessage"),
-            "Expected SettingsView offline banner to surface gateway.lastErrorMessage"
+            source.contains("DiagnosticsFormatter.redactSecrets"),
+            "Expected SettingsView offline banner to redact gateway.lastErrorMessage via DiagnosticsFormatter.redactSecrets"
         )
 
         XCTAssertFalse(

--- a/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
+++ b/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
@@ -86,4 +86,24 @@ final class SettingsViewRenderingRegressionTests: XCTestCase {
         XCTAssertTrue(source.contains("settings.diagnostics.lastSuccessAt"))
         XCTAssertTrue(source.contains("settings.diagnostics.lastError"))
     }
+
+    func testSettingsSource_rendersGatewayConnectionErrorBannerWhenOffline() throws {
+        let settingsViewPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // .../Tests/HackPanelAppTests
+            .deletingLastPathComponent() // .../Tests
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent("Sources/HackPanelApp/UI/SettingsView.swift")
+
+        let source = try String(contentsOf: settingsViewPath, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("Not connected to Gateway"),
+            "Expected SettingsView to render an explicit offline/unreachable gateway banner"
+        )
+
+        XCTAssertTrue(
+            source.contains("gateway.lastErrorMessage"),
+            "Expected SettingsView offline banner to surface gateway.lastErrorMessage"
+        )
+    }
 }

--- a/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
+++ b/Tests/HackPanelAppTests/SettingsViewRenderingRegressionTests.swift
@@ -105,5 +105,10 @@ final class SettingsViewRenderingRegressionTests: XCTestCase {
             source.contains("gateway.lastErrorMessage"),
             "Expected SettingsView offline banner to surface gateway.lastErrorMessage"
         )
+
+        XCTAssertFalse(
+            source.contains("127.0.0.1"),
+            "Settings UI should not hardcode localhost examples; it should be neutral for remote/Tailscale setups"
+        )
     }
 }


### PR DESCRIPTION
Users reported the Settings tab sometimes renders as a blank screen, especially when the OpenClaw Gateway is not running locally.

Changes:
- Avoid nested navigation containers in the Settings route (SwiftUI split-view detail can render blank when wrapped in an extra NavigationStack)
- Settings now always renders and shows an explicit offline/unreachable banner when the Gateway is not connected
- Adds a lightweight regression test to ensure the offline banner is present in SettingsView source

Notes:
- HackPanel connects to the OpenClaw Gateway WebSocket RPC endpoint (default http://127.0.0.1:18789/). The Gateway multiplexes WS + HTTP on the same port.

Test plan:
- `swift test`
- Run app with Gateway stopped; open Settings and confirm URL/token fields render and an explicit connection error is shown
